### PR TITLE
Implement flatten transform

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaType;
+
+@RequiredArgsConstructor
+public class FlattenStep implements TransformStep {
+  // TODO: Remove dependency on Avro's Field default value. It will not work with Union schemas "org.apache.avro.AvroTypeException: Invalid default for field a: "cloth" not a ["null","string"]"
+  // TODO: Cache schema to flattened schema
+  // TODO: Make flatten delimiter configurable
+  // TODO: Validate flatten delimiter if possible
+  // TODO: Microbenchmark the flatten algorithm to optimize if needed
+  // TODO: Add unit tests for schemas other than string for the unnested schema
+  // TODO: Add unit test for non-KeyValue schemas
+  // TODO: Add unit tests for Union schemas
+  // TODO: Add integration test
+
+  private static final String FLATTEN_DELIMITER = "_"; // '.' in not valid in AVRO field names
+  private final Optional<String> part;
+
+  @Override
+  public void process(TransformContext transformContext) throws Exception {
+    Schema<?> keySchema = transformContext.getKeySchema();
+    if (keySchema == null) {
+      return;
+    }
+    if (keySchema.getSchemaInfo().getType() == SchemaType.AVRO
+        && transformContext.getValueSchema().getSchemaInfo().getType() == SchemaType.AVRO) {
+
+      if (!part.isPresent()) {
+        validateAvro(transformContext.getKeySchema().getSchemaInfo().getType());
+        validateAvro(transformContext.getValueSchema().getSchemaInfo().getType());
+        GenericRecord avroKeyRecord = (GenericRecord) transformContext.getKeyObject();
+        GenericRecord avroValueRecord = (GenericRecord) transformContext.getValueObject();
+        transformContext.setKeyObject(flattenGenericRecord(avroKeyRecord));
+        transformContext.setValueObject(flattenGenericRecord(avroValueRecord));
+        transformContext.setKeyModified(true);
+        transformContext.setValueModified(true);
+      } else if (part.isPresent() && "key".equals(part.get())) {
+        validateAvro(transformContext.getKeySchema().getSchemaInfo().getType());
+        GenericRecord avroKeyRecord = (GenericRecord) transformContext.getKeyObject();
+        transformContext.setKeyObject(flattenGenericRecord(avroKeyRecord));
+        transformContext.setKeyModified(true);
+      } else if (part.isPresent() && "value".equals(part.get())) {
+        validateAvro(transformContext.getValueSchema().getSchemaInfo().getType());
+        GenericRecord avroValueRecord = (GenericRecord) transformContext.getValueObject();
+        transformContext.setValueObject(flattenGenericRecord(avroValueRecord));
+        transformContext.setValueModified(true);
+      } else {
+        throw new IllegalArgumentException("Unsupported part for Flatten: " + part.get());
+      }
+    }
+  }
+
+  void validateAvro(SchemaType schemaType) {
+    if (schemaType == SchemaType.AVRO) {
+      return;
+    }
+
+    throw new IllegalStateException("Unsupported schema type for Flatten: " + schemaType);
+  }
+
+  GenericRecord flattenGenericRecord(GenericRecord record) {
+    org.apache.avro.Schema modified = buildFlattenedSchema(record);
+    GenericRecord newRecord = new GenericData.Record(modified);
+    for (org.apache.avro.Schema.Field field : modified.getFields()) {
+      newRecord.put(field.name(), field.defaultVal());
+    }
+    return newRecord;
+  }
+
+  org.apache.avro.Schema buildFlattenedSchema(GenericRecord record) {
+    org.apache.avro.Schema originalSchema = record.getSchema();
+    List<org.apache.avro.Schema.Field> flattenedFields = new ArrayList<>();
+    for (org.apache.avro.Schema.Field field : originalSchema.getFields()) {
+      flattenedFields.addAll(flattenField(record, field, ""));
+    }
+    org.apache.avro.Schema flattenedSchema =
+        org.apache.avro.Schema.createRecord(
+            originalSchema.getName(),
+            originalSchema.getDoc(),
+            originalSchema.getNamespace(),
+            false,
+            flattenedFields);
+
+    return flattenedSchema;
+  }
+
+  List<org.apache.avro.Schema.Field> flattenField(
+      GenericRecord record, org.apache.avro.Schema.Field field, String flattenedFieldName) {
+    List<org.apache.avro.Schema.Field> flattenedFields = new ArrayList<>();
+    if (field.schema().getType() == org.apache.avro.Schema.Type.RECORD) {
+      for (org.apache.avro.Schema.Field nestedField : field.schema().getFields()) {
+        flattenedFields.addAll(
+            flattenField(
+                (GenericRecord) record.get(field.name()),
+                nestedField,
+                flattenedFieldName + field.name() + FLATTEN_DELIMITER));
+      }
+
+      return flattenedFields;
+    }
+
+    org.apache.avro.Schema.Field flattenedField =
+        new org.apache.avro.Schema.Field(
+            flattenedFieldName + field.name(),
+            field.schema(),
+            field.doc(),
+            record.get(field.name()),
+            field.order());
+
+    flattenedFields.add(flattenedField);
+
+    return flattenedFields;
+  }
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -52,9 +52,10 @@ import org.apache.pulsar.functions.api.Record;
  *       and make it the record value. If parameter <code>unwrapKey</code> is present and set to
  *       <code>true</code>, extract the KeyValue's key instead.
  *   <li><code>flatten</code>: flattens a nested structure selected in the <code>part</code> by
- *       concatenating nested field names with a '_' and populating them as top level fields. <code>
- *       part</code> could be any of <code>key</code> or <code>value</code>. If not specify, flatten
- *       will apply key and value. <code>true</code>, extract the KeyValue's key instead.
+ *       concatenating nested field names with a <code>delimiter</code> and populating them as top
+ *       level fields. <code>
+ *       delimiter</code> defaults to '_'. <code>part</code> could be any of <code>key</code> or
+ *       <code>value</code>. If not specified, flatten will apply to key and value.
  * </ul>
  *
  * <p>The <code>TransformFunction</code> reads its configuration as Json from the {@link Context}
@@ -76,7 +77,7 @@ import org.apache.pulsar.functions.api.Record;
  *       "type": "cast", "schema-type": "STRING"
  *     },
  *     {
- *       "type": "flatten", "part" : "value"
+ *       "type": "flatten", "delimiter" : "_" "part" : "value"
  *     }
  *   ]
  * }
@@ -190,7 +191,7 @@ public class TransformFunction implements Function<GenericObject, Void>, Transfo
   }
 
   public static FlattenStep newFlattenFunction(Map<String, Object> step) {
-    return new FlattenStep(getStringConfig(step, "part"));
+    return new FlattenStep(getStringConfig(step, "delimiter"), getStringConfig(step, "part"));
   }
 
   private static UnwrapKeyValueStep newUnwrapKeyValueFunction(Map<String, Object> step) {

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FlattenStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FlattenStepTest.java
@@ -16,15 +16,13 @@
 package com.datastax.oss.pulsar.functions.transforms;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Optional;
 import org.apache.avro.Schema;
-import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.util.Utf8;
-import org.apache.avro.util.internal.JacksonUtils;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
@@ -42,7 +40,7 @@ public class FlattenStepTest {
 
     // when
     Utils.TestTypedMessageBuilder<?> message =
-        Utils.process(record, new FlattenStep(Optional.empty()));
+        Utils.process(record, new FlattenStep(Optional.empty(), Optional.empty()));
 
     // then (key & value remain unchanged)
     KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
@@ -67,13 +65,13 @@ public class FlattenStepTest {
   }
 
   @Test
-  void testNestedKeyValueRegularKeyValueFlattened() throws Exception {
+  void testNestedKeyValueFlattened() throws Exception {
     // given
     Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
 
     // when
     Utils.TestTypedMessageBuilder<?> message =
-        Utils.process(nestedKVRecord, new FlattenStep(Optional.empty()));
+        Utils.process(nestedKVRecord, new FlattenStep(Optional.empty(), Optional.empty()));
 
     // then
     KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
@@ -84,42 +82,96 @@ public class FlattenStepTest {
     GenericData.Record valueRecord =
         Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
 
-    assertEquals(keyRecord.getSchema().getFields().size(), 5);
-    assertEquals(keyRecord.get("level1KeyField1"), new Utf8("level1_Key1"));
-    assertEquals(keyRecord.get("level1KeyField2_level2KeyField1"), new Utf8("level2_Key1"));
-    assertEquals(
-        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField1"), new Utf8("level3_Key1"));
-    assertEquals(
-        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField2_level4KeyField1"),
-        new Utf8("level4_Key1"));
-    assertEquals(
-        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField2_level4KeyField2"),
-        new Utf8("level4_Key2"));
+    // Assert value flattened
+    GenericData.Record key =
+        (GenericData.Record)
+            ((GenericAvroRecord) ((KeyValue) nestedKVRecord.getValue().getNativeObject()).getKey())
+                .getAvroRecord();
+    assertSchemasFlattened(keyRecord, key);
+    assertValuesFlattened(keyRecord, key);
 
-    assertEquals(valueRecord.getSchema().getFields().size(), 5);
-    assertEquals(valueRecord.get("level1ValueField1"), new Utf8("level1_Value1"));
-    assertEquals(valueRecord.get("level1ValueField2_level2ValueField1"), new Utf8("level2_Value1"));
-    assertEquals(
-        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField1"),
-        new Utf8("level3_Value1"));
-    assertEquals(
-        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField2_level4ValueField1"),
-        new Utf8("level4_Value1"));
-    assertEquals(
-        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField2_level4ValueField2"),
-        new Utf8("level4_Value2"));
+    // Assert value flattened
+    GenericData.Record value =
+        (GenericData.Record)
+            ((GenericAvroRecord)
+                    ((KeyValue) nestedKVRecord.getValue().getNativeObject()).getValue())
+                .getAvroRecord();
+    assertSchemasFlattened(valueRecord, value);
+    assertValuesFlattened(valueRecord, value);
 
     assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
   }
 
   @Test
-  void testNestedKeyValueRegularKeyOnlyFlattened() throws Exception {
+  void testNestedValueFlattened() throws Exception {
+    // given
+    Record<GenericObject> record = Utils.createNestedAvroRecord(4, "myKey");
+
+    // when
+    Utils.TestTypedMessageBuilder<?> message =
+        Utils.process(record, new FlattenStep(Optional.empty(), Optional.of("value")));
+
+    // then
+    assertEquals(message.getKey(), "myKey");
+
+    GenericData.Record valueRecord =
+        Utils.getRecord(message.getSchema(), (byte[]) message.getValue());
+
+    // Assert value flattened
+    GenericData.Record value =
+        (GenericData.Record)
+            ((GenericAvroRecord) (record.getValue().getNativeObject())).getAvroRecord();
+    assertSchemasFlattened(valueRecord, value);
+    assertValuesFlattened(valueRecord, value);
+  }
+
+  @Test
+  void testNestedKeyValueFlattenedWithCustomerDelimiter() throws Exception {
     // given
     Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
 
     // when
     Utils.TestTypedMessageBuilder<?> message =
-        Utils.process(nestedKVRecord, new FlattenStep(Optional.of("key")));
+        Utils.process(
+            nestedKVRecord, new FlattenStep(Optional.of("_CUSTOM_DELIMITER_"), Optional.empty()));
+
+    // then
+    KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
+    KeyValue messageValue = (KeyValue) message.getValue();
+
+    GenericData.Record keyRecord =
+        Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+    GenericData.Record valueRecord =
+        Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+    // Assert value flattened
+    GenericData.Record key =
+        (GenericData.Record)
+            ((GenericAvroRecord) ((KeyValue) nestedKVRecord.getValue().getNativeObject()).getKey())
+                .getAvroRecord();
+    assertSchemasFlattened(keyRecord, key, "_CUSTOM_DELIMITER_");
+    assertValuesFlattened(keyRecord, key, "_CUSTOM_DELIMITER_");
+
+    // Assert value flattened
+    GenericData.Record value =
+        (GenericData.Record)
+            ((GenericAvroRecord)
+                    ((KeyValue) nestedKVRecord.getValue().getNativeObject()).getValue())
+                .getAvroRecord();
+    assertSchemasFlattened(valueRecord, value, "_CUSTOM_DELIMITER_");
+    assertValuesFlattened(valueRecord, value, "_CUSTOM_DELIMITER_");
+
+    assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+  }
+
+  @Test
+  void testNestedKeyValueKeyOnlyFlattened() throws Exception {
+    // given
+    Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+    // when
+    Utils.TestTypedMessageBuilder<?> message =
+        Utils.process(nestedKVRecord, new FlattenStep(Optional.of("_"), Optional.of("key")));
 
     // then
     KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
@@ -130,38 +182,33 @@ public class FlattenStepTest {
     GenericData.Record valueRecord =
         (GenericData.Record) ((GenericAvroRecord) messageValue.getValue()).getNativeObject();
 
-    assertEquals(keyRecord.getSchema().getFields().size(), 5);
-    assertEquals(keyRecord.get("level1KeyField1"), new Utf8("level1_Key1"));
-    assertEquals(keyRecord.get("level1KeyField2_level2KeyField1"), new Utf8("level2_Key1"));
-    assertEquals(
-        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField1"), new Utf8("level3_Key1"));
-    assertEquals(
-        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField2_level4KeyField1"),
-        new Utf8("level4_Key1"));
-    assertEquals(
-        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField2_level4KeyField2"),
-        new Utf8("level4_Key2"));
+    // Assert key flattened
+    GenericData.Record key =
+        (GenericData.Record)
+            ((GenericAvroRecord) ((KeyValue) nestedKVRecord.getValue().getNativeObject()).getKey())
+                .getAvroRecord();
+    assertSchemasFlattened(keyRecord, key);
+    assertValuesFlattened(keyRecord, key);
 
-    assertEquals(valueRecord.getSchema().getFields().size(), 2);
-    assertEquals(valueRecord.get("level1ValueField1"), "level1_Value1");
-    GenericData.Record level1Record = (GenericData.Record) valueRecord.get("level1ValueField2");
-    assertEquals(level1Record.get("level2ValueField1"), "level2_Value1");
-    GenericData.Record level2Record = (GenericData.Record) level1Record.get("level2ValueField2");
-    assertEquals(level2Record.get("level3ValueField1"), "level3_Value1");
-    GenericData.Record level3Record = (GenericData.Record) level2Record.get("level3ValueField2");
-    assertEquals(level3Record.get("level4ValueField1"), "level4_Value1");
-    assertEquals(level3Record.get("level4ValueField2"), "level4_Value2");
+    // Assert value unchanged
+    GenericData.Record value =
+        (GenericData.Record)
+            ((GenericAvroRecord)
+                    ((KeyValue) nestedKVRecord.getValue().getNativeObject()).getValue())
+                .getAvroRecord();
+    assertSame(valueRecord, value);
+
     assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
   }
 
   @Test
-  void testNestedKeyValueRegularValueOnlyFlattened() throws Exception {
+  void testNestedKeyValueValueOnlyFlattened() throws Exception {
     // given
     Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
 
     // when
     Utils.TestTypedMessageBuilder<?> message =
-        Utils.process(nestedKVRecord, new FlattenStep(Optional.of("value")));
+        Utils.process(nestedKVRecord, new FlattenStep(Optional.empty(), Optional.of("value")));
 
     // then
     KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
@@ -172,39 +219,145 @@ public class FlattenStepTest {
     GenericData.Record valueRecord =
         Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
 
-    assertEquals(keyRecord.getSchema().getFields().size(), 2);
-    assertEquals(keyRecord.get("level1KeyField1"), "level1_Key1");
-    GenericData.Record level1Record = (GenericData.Record) keyRecord.get("level1KeyField2");
-    assertEquals(level1Record.get("level2KeyField1"), "level2_Key1");
-    GenericData.Record level2Record = (GenericData.Record) level1Record.get("level2KeyField2");
-    assertEquals(level2Record.get("level3KeyField1"), "level3_Key1");
-    GenericData.Record level3Record = (GenericData.Record) level2Record.get("level3KeyField2");
-    assertEquals(level3Record.get("level4KeyField1"), "level4_Key1");
-    assertEquals(level3Record.get("level4KeyField2"), "level4_Key2");
-    assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    // Assert key unchanged
+    GenericData.Record key =
+        (GenericData.Record)
+            ((GenericAvroRecord) ((KeyValue) nestedKVRecord.getValue().getNativeObject()).getKey())
+                .getAvroRecord();
+    assertSame(keyRecord, key);
 
-    assertEquals(valueRecord.getSchema().getFields().size(), 5);
-    assertEquals(valueRecord.get("level1ValueField1"), new Utf8("level1_Value1"));
-    assertEquals(valueRecord.get("level1ValueField2_level2ValueField1"), new Utf8("level2_Value1"));
-    assertEquals(
-        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField1"),
-        new Utf8("level3_Value1"));
-    assertEquals(
-        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField2_level4ValueField1"),
-        new Utf8("level4_Value1"));
-    assertEquals(
-        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField2_level4ValueField2"),
-        new Utf8("level4_Value2"));
+    // Assert value flattened
+    GenericData.Record value =
+        (GenericData.Record)
+            ((GenericAvroRecord)
+                    ((KeyValue) nestedKVRecord.getValue().getNativeObject()).getValue())
+                .getAvroRecord();
+    assertSchemasFlattened(valueRecord, value);
+    assertValuesFlattened(valueRecord, value);
   }
 
   @Test
-  void testNestedKeyValueRegularInvalidType() {
+  void testNestedKeyValueInvalidType() {
     // given
     Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
 
     // then
     assertThrows(
         IllegalArgumentException.class,
-        () -> Utils.process(nestedKVRecord, new FlattenStep(Optional.of("invalid"))));
+        () ->
+            Utils.process(
+                nestedKVRecord, new FlattenStep(Optional.empty(), Optional.of("invalid"))));
+  }
+
+  private void assertSchemasFlattened(
+      GenericData.Record actual, GenericData.Record expected, String delimiter) {
+    assertEquals(actual.getSchema().getFields().size(), 8);
+
+    assertField(
+        actual.getSchema().getField("level1String"), expected.getSchema().getField("level1String"));
+    Schema.Field expectedL1 = expected.getSchema().getField("level1Record");
+    assertField(
+        actual.getSchema().getField(String.format("level1Record%1$slevel2String", delimiter)),
+        expectedL1.schema().getField("level2String"));
+    Schema.Field expectedL2 = expectedL1.schema().getField("level2Record");
+    assertField(
+        actual
+            .getSchema()
+            .getField(String.format("level1Record%1$slevel2Record%1$slevel3String", delimiter)),
+        expectedL2.schema().getField("level3String"));
+    Schema.Field expectedL3 = expectedL2.schema().getField("level3Record");
+    assertField(
+        actual
+            .getSchema()
+            .getField(
+                String.format(
+                    "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4String", delimiter)),
+        expectedL3.schema().getField("level4String"));
+    assertField(
+        actual
+            .getSchema()
+            .getField(
+                String.format(
+                    "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Integer", delimiter)),
+        expectedL3.schema().getField("level4Integer"));
+    assertField(
+        actual
+            .getSchema()
+            .getField(
+                String.format(
+                    "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Double", delimiter)),
+        expectedL3.schema().getField("level4Double"));
+    assertField(
+        actual
+            .getSchema()
+            .getField(
+                String.format(
+                    "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4StringWithProps",
+                    delimiter)),
+        expectedL3.schema().getField("level4StringWithProps"));
+    assertField(
+        actual
+            .getSchema()
+            .getField(
+                String.format(
+                    "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Union", delimiter)),
+        expectedL3.schema().getField("level4Union"));
+  }
+
+  private void assertSchemasFlattened(GenericData.Record actual, GenericData.Record expected) {
+    assertSchemasFlattened(actual, expected, "_");
+  }
+
+  private void assertValuesFlattened(
+      GenericData.Record actual, GenericData.Record expected, String delimiter) {
+    assertEquals(actual.getSchema().getFields().size(), 8);
+
+    assertEquals(actual.get("level1String"), new Utf8((String) expected.get("level1String")));
+    GenericData.Record expectedL1 = (GenericData.Record) expected.get("level1Record");
+    assertEquals(
+        actual.get(String.format("level1Record%1$slevel2String", delimiter)),
+        new Utf8((String) expectedL1.get("level2String")));
+    GenericData.Record expectedL2 = (GenericData.Record) expectedL1.get("level2Record");
+    assertEquals(
+        actual.get(String.format("level1Record%1$slevel2Record%1$slevel3String", delimiter)),
+        new Utf8((String) expectedL2.get("level3String")));
+    GenericData.Record expectedL3 = (GenericData.Record) expectedL2.get("level3Record");
+    assertEquals(
+        actual.get(
+            String.format(
+                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4String", delimiter)),
+        new Utf8((String) expectedL3.get("level4String")));
+    assertEquals(
+        actual.get(
+            String.format(
+                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Integer", delimiter)),
+        expectedL3.get("level4Integer"));
+    assertEquals(
+        actual.get(
+            String.format(
+                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Double", delimiter)),
+        expectedL3.get("level4Double"));
+    assertEquals(
+        actual.get(
+            String.format(
+                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4StringWithProps",
+                delimiter)),
+        new Utf8((String) expectedL3.get("level4StringWithProps")));
+    assertEquals(
+        actual.get(
+            String.format(
+                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Union", delimiter)),
+        new Utf8((String) expectedL3.get("level4Union")));
+  }
+
+  private void assertValuesFlattened(GenericData.Record actual, GenericData.Record expected) {
+    assertValuesFlattened(actual, expected, "_");
+  }
+
+  private void assertField(Schema.Field actual, Schema.Field expected) {
+    assertEquals(actual.schema(), expected.schema());
+    assertEquals(actual.doc(), expected.doc());
+    assertEquals(actual.defaultVal(), expected.defaultVal());
+    assertEquals(actual.getObjectProps(), expected.getObjectProps());
   }
 }

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FlattenStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FlattenStepTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Optional;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.util.Utf8;
+import org.apache.avro.util.internal.JacksonUtils;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class FlattenStepTest {
+
+  @Test
+  void testRegularKeyValueNotModified() throws Exception {
+    // given
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+
+    // when
+    Utils.TestTypedMessageBuilder<?> message =
+        Utils.process(record, new FlattenStep(Optional.empty()));
+
+    // then (key & value remain unchanged)
+    KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
+    KeyValue messageValue = (KeyValue) message.getValue();
+
+    GenericData.Record keyRecord =
+        Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+    GenericData.Record valueRecord =
+        Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+    assertEquals(keyRecord.getSchema().getFields().size(), 3);
+    assertEquals(keyRecord.get("keyField1"), new Utf8("key1"));
+    assertEquals(keyRecord.get("keyField2"), new Utf8("key2"));
+    assertEquals(keyRecord.get("keyField3"), new Utf8("key3"));
+
+    assertEquals(valueRecord.getSchema().getFields().size(), 3);
+    assertEquals(valueRecord.get("valueField1"), new Utf8("value1"));
+    assertEquals(valueRecord.get("valueField2"), new Utf8("value2"));
+    assertEquals(valueRecord.get("valueField3"), new Utf8("value3"));
+
+    assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+  }
+
+  @Test
+  void testNestedKeyValueRegularKeyValueFlattened() throws Exception {
+    // given
+    Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+    // when
+    Utils.TestTypedMessageBuilder<?> message =
+        Utils.process(nestedKVRecord, new FlattenStep(Optional.empty()));
+
+    // then
+    KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
+    KeyValue messageValue = (KeyValue) message.getValue();
+
+    GenericData.Record keyRecord =
+        Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+    GenericData.Record valueRecord =
+        Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+    assertEquals(keyRecord.getSchema().getFields().size(), 5);
+    assertEquals(keyRecord.get("level1KeyField1"), new Utf8("level1_Key1"));
+    assertEquals(keyRecord.get("level1KeyField2_level2KeyField1"), new Utf8("level2_Key1"));
+    assertEquals(
+        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField1"), new Utf8("level3_Key1"));
+    assertEquals(
+        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField2_level4KeyField1"),
+        new Utf8("level4_Key1"));
+    assertEquals(
+        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField2_level4KeyField2"),
+        new Utf8("level4_Key2"));
+
+    assertEquals(valueRecord.getSchema().getFields().size(), 5);
+    assertEquals(valueRecord.get("level1ValueField1"), new Utf8("level1_Value1"));
+    assertEquals(valueRecord.get("level1ValueField2_level2ValueField1"), new Utf8("level2_Value1"));
+    assertEquals(
+        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField1"),
+        new Utf8("level3_Value1"));
+    assertEquals(
+        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField2_level4ValueField1"),
+        new Utf8("level4_Value1"));
+    assertEquals(
+        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField2_level4ValueField2"),
+        new Utf8("level4_Value2"));
+
+    assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+  }
+
+  @Test
+  void testNestedKeyValueRegularKeyOnlyFlattened() throws Exception {
+    // given
+    Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+    // when
+    Utils.TestTypedMessageBuilder<?> message =
+        Utils.process(nestedKVRecord, new FlattenStep(Optional.of("key")));
+
+    // then
+    KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
+    KeyValue messageValue = (KeyValue) message.getValue();
+
+    GenericData.Record keyRecord =
+        Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+    GenericData.Record valueRecord =
+        (GenericData.Record) ((GenericAvroRecord) messageValue.getValue()).getNativeObject();
+
+    assertEquals(keyRecord.getSchema().getFields().size(), 5);
+    assertEquals(keyRecord.get("level1KeyField1"), new Utf8("level1_Key1"));
+    assertEquals(keyRecord.get("level1KeyField2_level2KeyField1"), new Utf8("level2_Key1"));
+    assertEquals(
+        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField1"), new Utf8("level3_Key1"));
+    assertEquals(
+        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField2_level4KeyField1"),
+        new Utf8("level4_Key1"));
+    assertEquals(
+        keyRecord.get("level1KeyField2_level2KeyField2_level3KeyField2_level4KeyField2"),
+        new Utf8("level4_Key2"));
+
+    assertEquals(valueRecord.getSchema().getFields().size(), 2);
+    assertEquals(valueRecord.get("level1ValueField1"), "level1_Value1");
+    GenericData.Record level1Record = (GenericData.Record) valueRecord.get("level1ValueField2");
+    assertEquals(level1Record.get("level2ValueField1"), "level2_Value1");
+    GenericData.Record level2Record = (GenericData.Record) level1Record.get("level2ValueField2");
+    assertEquals(level2Record.get("level3ValueField1"), "level3_Value1");
+    GenericData.Record level3Record = (GenericData.Record) level2Record.get("level3ValueField2");
+    assertEquals(level3Record.get("level4ValueField1"), "level4_Value1");
+    assertEquals(level3Record.get("level4ValueField2"), "level4_Value2");
+    assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+  }
+
+  @Test
+  void testNestedKeyValueRegularValueOnlyFlattened() throws Exception {
+    // given
+    Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+    // when
+    Utils.TestTypedMessageBuilder<?> message =
+        Utils.process(nestedKVRecord, new FlattenStep(Optional.of("value")));
+
+    // then
+    KeyValueSchema messageSchema = (KeyValueSchema) message.getSchema();
+    KeyValue messageValue = (KeyValue) message.getValue();
+
+    GenericData.Record keyRecord =
+        (GenericData.Record) ((GenericAvroRecord) messageValue.getKey()).getNativeObject();
+    GenericData.Record valueRecord =
+        Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+    assertEquals(keyRecord.getSchema().getFields().size(), 2);
+    assertEquals(keyRecord.get("level1KeyField1"), "level1_Key1");
+    GenericData.Record level1Record = (GenericData.Record) keyRecord.get("level1KeyField2");
+    assertEquals(level1Record.get("level2KeyField1"), "level2_Key1");
+    GenericData.Record level2Record = (GenericData.Record) level1Record.get("level2KeyField2");
+    assertEquals(level2Record.get("level3KeyField1"), "level3_Key1");
+    GenericData.Record level3Record = (GenericData.Record) level2Record.get("level3KeyField2");
+    assertEquals(level3Record.get("level4KeyField1"), "level4_Key1");
+    assertEquals(level3Record.get("level4KeyField2"), "level4_Key2");
+    assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+
+    assertEquals(valueRecord.getSchema().getFields().size(), 5);
+    assertEquals(valueRecord.get("level1ValueField1"), new Utf8("level1_Value1"));
+    assertEquals(valueRecord.get("level1ValueField2_level2ValueField1"), new Utf8("level2_Value1"));
+    assertEquals(
+        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField1"),
+        new Utf8("level3_Value1"));
+    assertEquals(
+        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField2_level4ValueField1"),
+        new Utf8("level4_Value1"));
+    assertEquals(
+        valueRecord.get("level1ValueField2_level2ValueField2_level3ValueField2_level4ValueField2"),
+        new Utf8("level4_Value2"));
+  }
+
+  @Test
+  void testNestedKeyValueRegularInvalidType() {
+    // given
+    Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+    // then
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Utils.process(nestedKVRecord, new FlattenStep(Optional.of("invalid"))));
+  }
+}

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
@@ -15,8 +15,11 @@
  */
 package com.datastax.oss.pulsar.functions.transforms;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -24,22 +27,31 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Record;
@@ -117,6 +129,91 @@ public class Utils {
         };
 
     return new TestRecord<>(keyValueSchema, genericObject, null);
+  }
+
+  public static Record<GenericObject> createNestedAvroKeyValueRecord(int levels) {
+    GenericAvroRecord keyRecord = createNestedAvroRecord(levels, "Key");
+    GenericAvroRecord valueRecord = createNestedAvroRecord(levels, "Value");
+
+    GenericObject genericObject =
+        new GenericObject() {
+          @Override
+          public SchemaType getSchemaType() {
+            return SchemaType.KEY_VALUE;
+          }
+
+          @Override
+          public Object getNativeObject() {
+            return new KeyValue<>(keyRecord, valueRecord);
+          }
+        };
+
+    Schema pulsarKeySchema =
+        new Utils.NativeSchemaWrapper(keyRecord.getAvroRecord().getSchema(), SchemaType.AVRO);
+    Schema pulsarValueSchema =
+        new Utils.NativeSchemaWrapper(valueRecord.getAvroRecord().getSchema(), SchemaType.AVRO);
+
+    Schema<
+            KeyValue<
+                org.apache.pulsar.client.api.schema.GenericRecord,
+                org.apache.pulsar.client.api.schema.GenericRecord>>
+        keyValueSchema =
+            org.apache.pulsar.client.api.Schema.KeyValue(
+                pulsarKeySchema, pulsarValueSchema, KeyValueEncodingType.SEPARATED);
+
+    return new Utils.TestRecord(keyValueSchema, genericObject, null);
+  }
+
+  /**
+   * Returns a nested Avro record with a certain number of levels. Example for levels = 4: {
+   * "level1KeyField1": "level1_Key1", "level1KeyField2": { "level2KeyField1": "level2_Key1",
+   * "level2KeyField2": { "level3KeyField1": "level3_Key1", "level3KeyField2": { "level4KeyField1":
+   * "level4_Key1", "level4KeyField2": "level4_Key2" } } } }
+   */
+  public static GenericAvroRecord createNestedAvroRecord(int levels, String type) {
+    // Create the last, unnested level
+    List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+    fields.add(
+        new org.apache.avro.Schema.Field(
+            "level" + levels + type + "Field1",
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING)));
+    fields.add(
+        new org.apache.avro.Schema.Field(
+            "level" + levels + type + "Field2",
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING)));
+    org.apache.avro.Schema lastLevelSchema =
+        org.apache.avro.Schema.createRecord("nested" + levels, "doc ", "ns", false, fields);
+    org.apache.avro.generic.GenericRecord lastLevelRecord = new GenericData.Record(lastLevelSchema);
+    lastLevelRecord.put("level" + levels + type + "Field1", "level" + levels + "_" + type + "1");
+    lastLevelRecord.put("level" + levels + type + "Field2", "level" + levels + "_" + type + "2");
+
+    org.apache.avro.Schema nextLevelSchema = lastLevelSchema;
+    org.apache.avro.generic.GenericRecord nextLevelRecord = lastLevelRecord;
+    // Create the nested levels one by one, working backwards from the last level up to the top
+    // level
+    for (int level = levels - 1; level > 0; level--) {
+      fields = new ArrayList<>();
+      fields.add(
+          new org.apache.avro.Schema.Field(
+              "level" + level + type + "Field1",
+              org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING)));
+      fields.add(
+          new org.apache.avro.Schema.Field("level" + level + type + "Field2", nextLevelSchema));
+      org.apache.avro.Schema currentLevelSchema =
+          org.apache.avro.Schema.createRecord("nested" + level, "doc ", "ns", false, fields);
+
+      org.apache.avro.generic.GenericRecord currentLevelRecord =
+          new GenericData.Record(currentLevelSchema);
+      currentLevelRecord.put("level" + level + type + "Field1", "level" + level + "_" + type + "1");
+      currentLevelRecord.put("level" + level + type + "Field2", nextLevelRecord);
+
+      nextLevelSchema = currentLevelSchema;
+      nextLevelRecord = currentLevelRecord;
+    }
+
+    List<Field> pulsarFields =
+        fields.stream().map(v -> new Field(v.name(), v.pos())).collect(Collectors.toList());
+    return new GenericAvroRecord(new byte[0], nextLevelSchema, pulsarFields, nextLevelRecord);
   }
 
   public static class TestRecord<T> implements Record<T> {
@@ -433,6 +530,91 @@ public class Utils {
 
     public Schema<T> getSchema() {
       return schema;
+    }
+  }
+
+  public static class NativeSchemaWrapper
+      implements org.apache.pulsar.client.api.Schema<org.apache.avro.generic.GenericRecord> {
+
+    private final SchemaInfo pulsarSchemaInfo;
+    private final org.apache.avro.Schema nativeSchema;
+
+    private final SchemaType pulsarSchemaType;
+
+    private final SpecificDatumWriter datumWriter;
+
+    public NativeSchemaWrapper(org.apache.avro.Schema nativeSchema, SchemaType pulsarSchemaType) {
+      this.nativeSchema = nativeSchema;
+      this.pulsarSchemaType = pulsarSchemaType;
+      this.pulsarSchemaInfo =
+          SchemaInfoImpl.builder()
+              .schema(nativeSchema.toString(false).getBytes(StandardCharsets.UTF_8))
+              .properties(new HashMap<>())
+              .type(pulsarSchemaType)
+              .name(nativeSchema.getName())
+              .build();
+      this.datumWriter = new SpecificDatumWriter<>(this.nativeSchema);
+    }
+
+    @Override
+    public byte[] encode(org.apache.avro.generic.GenericRecord genericRecord) {
+      try {
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        BinaryEncoder binaryEncoder =
+            new EncoderFactory().binaryEncoder(byteArrayOutputStream, null);
+        datumWriter.write(genericRecord, binaryEncoder);
+        binaryEncoder.flush();
+        return byteArrayOutputStream.toByteArray();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public SchemaInfo getSchemaInfo() {
+      return pulsarSchemaInfo;
+    }
+
+    @Override
+    public NativeSchemaWrapper clone() {
+      return new NativeSchemaWrapper(nativeSchema, pulsarSchemaType);
+    }
+
+    @Override
+    public void validate(byte[] message) {
+      // nothing to do
+    }
+
+    @Override
+    public boolean supportSchemaVersioning() {
+      return true;
+    }
+
+    @Override
+    public void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {}
+
+    @Override
+    public org.apache.avro.generic.GenericRecord decode(byte[] bytes) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public org.apache.avro.generic.GenericRecord decode(byte[] bytes, byte[] schemaVersion) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean requireFetchingSchemaInfo() {
+      return true;
+    }
+
+    @Override
+    public void configureSchemaInfo(String topic, String componentName, SchemaInfo schemaInfo) {}
+
+    @Override
+    public Optional<Object> getNativeSchema() {
+      return Optional.of(nativeSchema);
     }
   }
 }


### PR DESCRIPTION
First iteration of flatten transform. It works on the "key", "value", or both parts of the message. The delimiter used in this path is "_". Please note that in Avro, "." is not a valid field name: https://avro.apache.org/docs/1.11.1/specification/_print/#names

And example input is:
```JSON
{
    "level11": "key1",
    "level12": {
        "level21": "key2",
        "level22": {
            "level31": "key3",
            "level32": {
                "level41": "key4",
                "level42": "key5"
            }
        }
    }
}
```

After flattening becomes:
```JSON
{
  "level11": "key1",
  "level12_level21": "key2",
  "level12_level22_level31": "key3",
  "level12_level22_level32_level41": "key4" ,
  "level12_level22_level32_level41": "key5" 
}
```

This patch is working probably, but there are few items to follow up on (especially the first 1):
**To do list:** 
*  [Functionality: Blocker for Union types]Remove dependency on Avro's Field default value. It will not work with Union schemas "org.apache.avro.AvroTypeException: Invalid default for field a: "cloth" not a ["null","string"]"
  * [Performance] Cache schema to flattened schema
  * ~[DONE][UX] Make flatten delimiter configurable~
  * [UX] Validate flatten delimiter if possible
  * [Performance] Microbenchmark the flatten algorithm to optimize if needed
  * ~[DONE][Test Coverage] Add unit tests for schemas other than string for the unnested schema~
  * ~[DONE][Test Coverage] Add unit test for non-KeyValue schemas~
  * ~[DONE][Test Coverage] Add unit tests for Union schemas~
  * [e2e test] Add integration test