### PR TITLE
Read value object from transform context as org.apache.avro.generic.GenericRecord only

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
@@ -34,8 +34,8 @@ public class FlattenStep implements TransformStep {
 
   private static final String DEFAULT_DELIMITER = "_"; // '.' in not valid in AVRO field names
 
-  @Builder.Default private String delimiter = DEFAULT_DELIMITER;
-  private String part;
+  @Builder.Default private final String delimiter = DEFAULT_DELIMITER;
+  private final String part;
 
   @Override
   public void process(TransformContext transformContext) throws Exception {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
@@ -17,16 +17,15 @@ package com.datastax.oss.pulsar.functions.transforms;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaType;
 
-@RequiredArgsConstructor
+@Builder
 public class FlattenStep implements TransformStep {
   // TODO: Cache schema to flattened schema
   // TODO: Microbenchmark the flatten algorithm for performance optimization
@@ -35,12 +34,12 @@ public class FlattenStep implements TransformStep {
 
   private static final String DEFAULT_DELIMITER = "_"; // '.' in not valid in AVRO field names
 
-  private final Optional<String> delimiter;
-  private final Optional<String> part;
+  @Builder.Default private String delimiter = DEFAULT_DELIMITER;
+  private String part;
 
   @Override
   public void process(TransformContext transformContext) throws Exception {
-    if (!part.isPresent()) {
+    if (part == null) {
       validateAvro(transformContext.getKeySchema());
       validateAvro(transformContext.getValueSchema());
       GenericRecord avroKeyRecord = (GenericRecord) transformContext.getKeyObject();
@@ -49,25 +48,18 @@ public class FlattenStep implements TransformStep {
       transformContext.setValueObject(flattenGenericRecord(avroValueRecord));
       transformContext.setKeyModified(true);
       transformContext.setValueModified(true);
-    } else if (part.isPresent() && "key".equals(part.get())) {
+    } else if ("key".equals(part)) {
       validateAvro(transformContext.getKeySchema());
       GenericRecord avroKeyRecord = (GenericRecord) transformContext.getKeyObject();
       transformContext.setKeyObject(flattenGenericRecord(avroKeyRecord));
       transformContext.setKeyModified(true);
-    } else if (part.isPresent() && "value".equals(part.get())) {
+    } else if ("value".equals(part)) {
       validateAvro(transformContext.getValueSchema());
-      GenericRecord avroValueRecord =
-          (transformContext.getValueObject()
-                  instanceof org.apache.pulsar.client.api.schema.GenericRecord)
-              ? (GenericRecord)
-                  ((org.apache.pulsar.client.api.schema.GenericRecord)
-                          transformContext.getValueObject())
-                      .getNativeObject()
-              : (GenericRecord) transformContext.getValueObject();
+      GenericRecord avroValueRecord = (GenericRecord) transformContext.getValueObject();
       transformContext.setValueObject(flattenGenericRecord(avroValueRecord));
       transformContext.setValueModified(true);
     } else {
-      throw new IllegalArgumentException("Unsupported part for Flatten: " + part.get());
+      throw new IllegalArgumentException("Unsupported part for Flatten: " + part);
     }
   }
 
@@ -127,9 +119,7 @@ public class FlattenStep implements TransformStep {
       for (org.apache.avro.Schema.Field nestedField : genericRecord.getSchema().getFields()) {
         flattenedFields.addAll(
             flattenField(
-                genericRecord,
-                nestedField,
-                flattenedFieldName + field.name() + delimiter.orElse(DEFAULT_DELIMITER)));
+                genericRecord, nestedField, flattenedFieldName + field.name() + delimiter));
       }
 
       return flattenedFields;

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -191,7 +191,10 @@ public class TransformFunction implements Function<GenericObject, Void>, Transfo
   }
 
   public static FlattenStep newFlattenFunction(Map<String, Object> step) {
-    return new FlattenStep(getStringConfig(step, "delimiter"), getStringConfig(step, "part"));
+    FlattenStep.FlattenStepBuilder builder = FlattenStep.builder();
+    getStringConfig(step, "part").map(part -> builder.part(part));
+    getStringConfig(step, "delimiter").map(delimiter -> builder.delimiter(delimiter));
+    return builder.build();
   }
 
   private static UnwrapKeyValueStep newUnwrapKeyValueFunction(Map<String, Object> step) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -192,8 +192,8 @@ public class TransformFunction implements Function<GenericObject, Void>, Transfo
 
   public static FlattenStep newFlattenFunction(Map<String, Object> step) {
     FlattenStep.FlattenStepBuilder builder = FlattenStep.builder();
-    getStringConfig(step, "part").map(part -> builder.part(part));
-    getStringConfig(step, "delimiter").map(delimiter -> builder.delimiter(delimiter));
+    getStringConfig(step, "part").ifPresent(builder::part);
+    getStringConfig(step, "delimiter").ifPresent(builder::delimiter);
     return builder.build();
   }
 

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
@@ -135,23 +135,19 @@ public class Utils {
   public static Record<GenericObject> createNestedAvroRecord(int levels, String key) {
     GenericAvroRecord valueRecord = createNestedAvroRecord(levels);
 
-    GenericObject genericObject =
-        new GenericObject() {
-          @Override
-          public SchemaType getSchemaType() {
-            return SchemaType.AVRO;
-          }
-
-          @Override
-          public Object getNativeObject() {
-            return valueRecord;
-          }
-        };
-
     Schema pulsarValueSchema =
         new Utils.NativeSchemaWrapper(valueRecord.getAvroRecord().getSchema(), SchemaType.AVRO);
 
-    return new Utils.TestRecord(pulsarValueSchema, genericObject, key);
+    return new Utils.TestRecord(pulsarValueSchema, valueRecord, key);
+  }
+
+  public static Record<GenericObject> createNestedJSONRecord(int levels, String key) {
+    GenericAvroRecord valueRecord = createNestedAvroRecord(levels);
+
+    Schema pulsarValueSchema =
+        new Utils.NativeSchemaWrapper(valueRecord.getAvroRecord().getSchema(), SchemaType.JSON);
+
+    return new Utils.TestRecord(pulsarValueSchema, valueRecord, key);
   }
 
   public static Record<GenericObject> createNestedAvroKeyValueRecord(int levels) {


### PR DESCRIPTION
Addressed feedback for the preview (#4):
* Remove the code that maps the object value from the transform context as GenericAvroRecord
* Avoid using optional class members on the FlattenStep
* Add unit tests for thrown exception  