### PR TITLE
Add JMS filters based predicate to transformation steps

### DIFF
--- a/pulsar-transformations/pom.xml
+++ b/pulsar-transformations/pom.xml
@@ -72,6 +72,21 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>${pulsar.groupId}</groupId>
+      <artifactId>pulsar-jms-filters</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!--    <dependency>-->
+    <!--      <groupId>javax.resource</groupId>-->
+    <!--      <artifactId>javax.resource-api</artifactId>-->
+    <!--      <scope>provided</scope>-->
+    <!--    </dependency>-->
+    <!--    <dependency>-->
+    <!--      <groupId>jakarta.jms</groupId>-->
+    <!--      <artifactId>jakarta.jms-api</artifactId>-->
+    <!--      <scope>provided</scope>-->
+    <!--    </dependency>-->
   </dependencies>
   <build>
     <plugins>

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/JmsPredicate.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/JmsPredicate.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import com.datastax.oss.pulsar.jms.selectors.SelectorSupport;
+import java.util.function.Predicate;
+import javax.jms.JMSException;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.pulsar.client.api.Message;
+
+public class JmsPredicate implements Predicate<TransformContext> {
+
+  private final SelectorSupport selector;
+
+  public JmsPredicate(String filter) {
+    try {
+      // A hacky way in to init the predicate as JMS filters doesn't accept . in field names,
+      // Parsing and passing a positional list of ket/value is tricky as we need to understand the
+      // SQL syntax
+      // TODO: Find a better way to handle the scope of the field
+      String sanitizedFilter =
+          filter.replaceAll("key\\.", "key\\$").replaceAll("value\\.", "value\\$");
+      selector = SelectorSupport.build(sanitizedFilter, true);
+    } catch (JMSException ex) {
+      throw new IllegalArgumentException("invalid filter: " + filter, ex);
+    }
+  }
+
+  @Override
+  public boolean test(TransformContext transformContext) {
+    try {
+      return selector.matches((key) -> fieldAccessor(key, transformContext));
+    } catch (JMSException ex) {
+      throw new RuntimeException("failed to test predicate", ex);
+    }
+  }
+
+  private Object fieldAccessor(String field, TransformContext context) {
+    String scope = null;
+    String key = field;
+    if (field.startsWith("key$") || field.startsWith("value$")) {
+      String[] filterParts = field.split("\\$", 2);
+      scope = filterParts[0];
+      key = filterParts[1];
+    }
+
+    if (scope == null) {
+      Message message = context.getContext().getCurrentRecord().getMessage().orElse(null);
+      return message == null ? null : message.getProperties().get(key);
+    } else if ("key".equals(scope) && context.getKeyObject() instanceof GenericRecord) {
+      GenericRecord record = (GenericRecord) context.getKeyObject();
+      return record.hasField(key) ? record.get(key) : null;
+    } else if ("value".equals(scope) && context.getValueObject() instanceof GenericRecord) {
+      GenericRecord record = (GenericRecord) context.getValueObject();
+      return record.hasField(key) ? record.get(key) : null;
+    }
+    return null; // should never happen
+  }
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/StepPredicatePair.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/StepPredicatePair.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import java.util.function.Predicate;
+import lombok.Data;
+
+@Data
+public class StepPredicatePair {
+  private final TransformStep transformStep;
+  private final Predicate<TransformContext> predicate;
+}

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FiltersTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FiltersTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import com.datastax.oss.pulsar.jms.selectors.SelectorSupport;
+import javax.jms.JMSException;
+import org.testng.annotations.Test;
+
+public class FiltersTest {
+
+  @Test
+  public void testFilter() throws JMSException {
+    SelectorSupport ss = SelectorSupport.build("prop1 = 'my-prop1' AND prop2 = 'my-prop12'", true);
+
+    boolean m =
+        ss.matches(
+            (a) -> {
+              switch (a) {
+                case "prop1":
+                  return "my-prop1";
+                case "prop2":
+                  return "my-prop12";
+                default:
+                  return "";
+              }
+            });
+
+    System.out.println(m);
+  }
+}

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/JmsPredicateTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/JmsPredicateTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.HashMap;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class JmsPredicateTest {
+
+  @Test
+  void testKeyScope() {
+    JmsPredicate match = new JmsPredicate("key.keyField1='key1' AND key.keyField2='key2'");
+    JmsPredicate matchLike = new JmsPredicate("key.keyField1 LIKE '%k%'");
+    JmsPredicate dontMatch = new JmsPredicate("value.keyField1 ='key1'");
+    JmsPredicate dontMatchLike = new JmsPredicate("key.keyField1 LIKE '%value%'");
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    assertTrue(match.test(transformContext));
+    assertTrue(matchLike.test(transformContext));
+    assertFalse(dontMatch.test(transformContext));
+    assertFalse(dontMatchLike.test(transformContext));
+  }
+
+  @Test
+  void testValueScope() {
+    JmsPredicate match =
+        new JmsPredicate("value.valueField1='value1' AND value.valueField2='value2'");
+    JmsPredicate matchLike = new JmsPredicate("value.valueField1 LIKE '%val%'");
+    JmsPredicate dontMatch = new JmsPredicate("key.valueField1 ='value1'");
+    JmsPredicate dontMatchLike = new JmsPredicate("value.valueField1 LIKE '%key%'");
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    assertTrue(match.test(transformContext));
+    assertTrue(matchLike.test(transformContext));
+    assertFalse(dontMatch.test(transformContext));
+    assertFalse(dontMatchLike.test(transformContext));
+  }
+
+  @Test
+  void testMessageProps() {
+    JmsPredicate match = new JmsPredicate("p1='value1' AND p2='value2'");
+    JmsPredicate matchLike = new JmsPredicate("p1 LIKE '%val%'");
+    JmsPredicate dontMatch = new JmsPredicate("p1='key1'");
+    JmsPredicate dontMatchLike = new JmsPredicate("p1 LIKE '%key%'");
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    assertTrue(match.test(transformContext));
+    assertTrue(matchLike.test(transformContext));
+    assertFalse(dontMatch.test(transformContext));
+    assertFalse(dontMatchLike.test(transformContext));
+  }
+
+  @Test
+  void testMessageKeyValueProps() {
+    JmsPredicate match =
+        new JmsPredicate(
+            "key.keyField1='key1' AND key.keyField2='key2' "
+                + "AND value.valueField1='value1' AND value.valueField2='value2' AND p1='value1' AND p2='value2'");
+    JmsPredicate matchLike =
+        new JmsPredicate(
+            "key.keyField1 LIKE '%k%' AND value.valueField1 LIKE '%val%' AND p1 LIKE '%val%'");
+    JmsPredicate dontMatch =
+        new JmsPredicate(
+            "key.keyField1='key1' AND key.keyField2='key2' "
+                + "AND value.valueField1='value1' AND value.valueField2='value2' AND p1='value1' AND p2='value3'");
+    JmsPredicate dontMatchLike =
+        new JmsPredicate(
+            "key.keyField1 LIKE '%k%' AND value.valueField1 LIKE '%val%' AND p1 LIKE '%random%'");
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    assertTrue(match.test(transformContext));
+    assertTrue(matchLike.test(transformContext));
+    assertFalse(dontMatch.test(transformContext));
+    assertFalse(dontMatchLike.test(transformContext));
+  }
+}

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
@@ -39,6 +39,7 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
@@ -48,8 +49,10 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
 import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
+import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -281,6 +284,22 @@ public class Utils {
     @Override
     public T getValue() {
       return value;
+    }
+
+    @Override
+    public Optional<Message<T>> getMessage() {
+      MessageMetadata metadata = new MessageMetadata();
+      List<org.apache.pulsar.common.api.proto.KeyValue> properties = new ArrayList<>();
+      properties.add(
+          new org.apache.pulsar.common.api.proto.KeyValue().setKey("p1").setValue("value1"));
+      properties.add(
+          new org.apache.pulsar.common.api.proto.KeyValue().setKey("p2").setValue("value2"));
+      properties.add(
+          new org.apache.pulsar.common.api.proto.KeyValue().setKey("p3").setValue("value3"));
+      metadata.addAllProperties(properties);
+      Message message = MessageImpl.create(metadata, ByteBuffer.wrap(new byte[0]), null, "topic");
+
+      return Optional.of(message);
     }
   }
 


### PR DESCRIPTION
This is the first iteration of adding JSM filters as predicates to enable/disable a specific step. The idea is to add an optional filter config to each step, for example:

```
"{\"steps\": 
   [{\"type\": \"drop-fields\", \"fields\": \"body\", 
     \"filter\":\"value.title = 'title' AND key.id = 'title' AND property LIKE '%prop%'\"}]}"
```

Fields in the predicate can be prefixed by key or value to access the respective field from the generic record. If no prefix is provided, the field name applies by default to the custom message properties provided.

TODO:
* The JMS selector doesn't accept a "."  in the field name. A workaround is implement to replace "." with "$" just to showcase the complete use case. I think we should try to avoid parsing the SQL predicate ourselves to preprocess the field names. Alternative options is to have the user pass the scope of the fields separately on the step config. 
* Integ tests is not yet possible, when running the functions in localrun mode, it fails to load the JMS dependecies: 
```
java.lang.NoClassDefFoundError: javax/jms/JMSException
```
* Message header matching other than the user defined props

 