### PR TITLE
Implement jstl based step predicates 

### DIFF
--- a/pulsar-transformations/pom.xml
+++ b/pulsar-transformations/pom.xml
@@ -72,6 +72,29 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>pulsar-jms-filters</artifactId>
+      <version>2.4.6</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/de.odysseus.juel/juel-api -->
+    <dependency>
+      <groupId>de.odysseus.juel</groupId>
+      <artifactId>juel-api</artifactId>
+      <version>2.2.7</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/de.odysseus.juel/juel-impl -->
+    <dependency>
+      <groupId>de.odysseus.juel</groupId>
+      <artifactId>juel-impl</artifactId>
+      <version>2.2.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.4</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pulsar-transformations/pom.xml
+++ b/pulsar-transformations/pom.xml
@@ -72,11 +72,6 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>pulsar-jms-filters</artifactId>
-      <version>2.4.6</version>
-    </dependency>
     <!-- https://mvnrepository.com/artifact/de.odysseus.juel/juel-api -->
     <dependency>
       <groupId>de.odysseus.juel</groupId>

--- a/pulsar-transformations/pom.xml
+++ b/pulsar-transformations/pom.xml
@@ -88,7 +88,6 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
       <version>4.4</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/StepPredicatePair.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/StepPredicatePair.java
@@ -15,13 +15,17 @@
  */
 package com.datastax.oss.pulsar.functions.transforms.predicate;
 
-import com.datastax.oss.pulsar.functions.transforms.TransformContext;
 import com.datastax.oss.pulsar.functions.transforms.TransformStep;
-import java.util.function.Predicate;
 import lombok.Data;
 
+/**
+ * A convenience class to group a step and its predicate together. A convenience class to group a
+ * step and its predicate together.
+ */
 @Data
 public class StepPredicatePair {
+  /** The candidate transform step to be invoked. */
   private final TransformStep transformStep;
-  private final Predicate<TransformContext> predicate;
+  /** A predicate that decides whether the transform step should be invoked or not. */
+  private final TransformPredicate predicate;
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/StepPredicatePair.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/StepPredicatePair.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.predicate;
+
+import com.datastax.oss.pulsar.functions.transforms.TransformContext;
+import com.datastax.oss.pulsar.functions.transforms.TransformStep;
+import java.util.function.Predicate;
+import lombok.Data;
+
+@Data
+public class StepPredicatePair {
+  private final TransformStep transformStep;
+  private final Predicate<TransformContext> predicate;
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/TransformPredicate.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/TransformPredicate.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.predicate;
+
+import com.datastax.oss.pulsar.functions.transforms.TransformContext;
+import java.util.function.Predicate;
+
+/** A predicate functional interface that applies to {@link TransformContext}. */
+@FunctionalInterface
+public interface TransformPredicate extends Predicate<TransformContext> {}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/TransformPredicate.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/TransformPredicate.java
@@ -18,6 +18,10 @@ package com.datastax.oss.pulsar.functions.transforms.predicate;
 import com.datastax.oss.pulsar.functions.transforms.TransformContext;
 import java.util.function.Predicate;
 
-/** A predicate functional interface that applies to {@link TransformContext}. */
+/**
+ * A predicate functional interface that applies to {@link TransformContext}. Implementations of
+ * this interface should respect the current record encapsulated in the {@link TransformContext}
+ * when evaluating the predicate.
+ */
 @FunctionalInterface
 public interface TransformPredicate extends Predicate<TransformContext> {}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicate.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicate.java
@@ -17,17 +17,15 @@ package com.datastax.oss.pulsar.functions.transforms.predicate.jstl;
 
 import com.datastax.oss.pulsar.functions.transforms.TransformContext;
 import com.datastax.oss.pulsar.functions.transforms.predicate.TransformPredicate;
-import de.odysseus.el.tree.TreeBuilderException;
 import de.odysseus.el.util.SimpleContext;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.commons.collections4.Transformer;
-import org.apache.commons.collections4.map.LazyMap;
-
+import java.util.HashMap;
+import java.util.Map;
 import javax.el.ELContext;
 import javax.el.ExpressionFactory;
 import javax.el.ValueExpression;
-import java.util.HashMap;
-import java.util.Map;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.map.LazyMap;
 
 /** A {@link TransformPredicate} implementation based on the Uniform Transform Language. */
 public class JstlPredicate implements TransformPredicate {
@@ -38,8 +36,10 @@ public class JstlPredicate implements TransformPredicate {
   public JstlPredicate(String when) {
     this.expressionContext = new SimpleContext();
     try {
-      this.valueExpression = FACTORY.createValueExpression(expressionContext, when, boolean.class);
-    } catch (TreeBuilderException ex) {
+      final String expression = String.format("${%s}", when);
+      this.valueExpression =
+          FACTORY.createValueExpression(expressionContext, expression, boolean.class);
+    } catch (RuntimeException ex) {
       throw new IllegalArgumentException("invalid when: " + when, ex);
     }
   }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicate.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicate.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.predicate.jstl;
+
+import com.datastax.oss.pulsar.functions.transforms.TransformContext;
+import com.datastax.oss.pulsar.functions.transforms.predicate.TransformPredicate;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.TreeBuilderException;
+import de.odysseus.el.tree.impl.Builder;
+import de.odysseus.el.util.SimpleContext;
+import java.util.HashMap;
+import java.util.Map;
+import javax.el.ELContext;
+import javax.el.ExpressionFactory;
+import javax.el.ValueExpression;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.map.LazyMap;
+
+/** A {@link TransformPredicate} implementation based on the Uniform Transform Language. */
+public class JstlPredicate implements TransformPredicate {
+  private static final Builder BUILDER = new Builder(Builder.Feature.METHOD_INVOCATIONS);
+
+  private static final Bindings BINDINGS = new Bindings(null, null, null);
+  private static final ExpressionFactory FACTORY = new de.odysseus.el.ExpressionFactoryImpl();
+  private final ValueExpression valueExpression;
+  private final ELContext expressionContext;
+
+  String when;
+
+  public JstlPredicate(String when) {
+    this.expressionContext = new SimpleContext();
+    this.when = when;
+    try {
+      this.valueExpression = FACTORY.createValueExpression(expressionContext, when, boolean.class);
+    } catch (TreeBuilderException ex) {
+      throw new IllegalArgumentException("invalid when: " + when, ex);
+    }
+  }
+
+  @Override
+  public boolean test(TransformContext transformContext) {
+    JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+    FACTORY
+        .createValueExpression(expressionContext, "${key}", Map.class)
+        .setValue(expressionContext, adapter.getKey());
+    FACTORY
+        .createValueExpression(expressionContext, "${value}", Map.class)
+        .setValue(expressionContext, adapter.getValue());
+    FACTORY
+        .createValueExpression(expressionContext, "${header}", Map.class)
+        .setValue(expressionContext, adapter.getHeader());
+    return (boolean) this.valueExpression.getValue(expressionContext);
+  }
+
+  static class GenericRecordTransformer implements Transformer<String, Object> {
+
+    GenericRecord genericRecord;
+
+    public GenericRecordTransformer(GenericRecord genericRecord) {
+      this.genericRecord = genericRecord;
+    }
+
+    @Override
+    public Object transform(String key) {
+      Object value = null;
+      if (genericRecord.hasField(key)) {
+        value = genericRecord.get(key);
+        if (value instanceof GenericRecord) {
+          value =
+              LazyMap.lazyMap(new HashMap<>(), new GenericRecordTransformer((GenericRecord) value));
+        }
+      }
+
+      return value;
+    }
+  }
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicate.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicate.java
@@ -17,24 +17,20 @@ package com.datastax.oss.pulsar.functions.transforms.predicate.jstl;
 
 import com.datastax.oss.pulsar.functions.transforms.TransformContext;
 import com.datastax.oss.pulsar.functions.transforms.predicate.TransformPredicate;
-import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.TreeBuilderException;
-import de.odysseus.el.tree.impl.Builder;
 import de.odysseus.el.util.SimpleContext;
-import java.util.HashMap;
-import java.util.Map;
-import javax.el.ELContext;
-import javax.el.ExpressionFactory;
-import javax.el.ValueExpression;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.map.LazyMap;
 
+import javax.el.ELContext;
+import javax.el.ExpressionFactory;
+import javax.el.ValueExpression;
+import java.util.HashMap;
+import java.util.Map;
+
 /** A {@link TransformPredicate} implementation based on the Uniform Transform Language. */
 public class JstlPredicate implements TransformPredicate {
-  private static final Builder BUILDER = new Builder(Builder.Feature.METHOD_INVOCATIONS);
-
-  private static final Bindings BINDINGS = new Bindings(null, null, null);
   private static final ExpressionFactory FACTORY = new de.odysseus.el.ExpressionFactoryImpl();
   private final ValueExpression valueExpression;
   private final ELContext expressionContext;

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicate.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicate.java
@@ -35,11 +35,8 @@ public class JstlPredicate implements TransformPredicate {
   private final ValueExpression valueExpression;
   private final ELContext expressionContext;
 
-  String when;
-
   public JstlPredicate(String when) {
     this.expressionContext = new SimpleContext();
-    this.when = when;
     try {
       this.valueExpression = FACTORY.createValueExpression(expressionContext, when, boolean.class);
     } catch (TreeBuilderException ex) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapter.java
@@ -68,25 +68,21 @@ public class JstlTransformContextAdapter {
   private Transformer<String, Object> headerTransformer =
       (fieldName) -> {
         Record<?> currentRecord = transformContext.getContext().getCurrentRecord();
-        return currentRecord
-            .getMessage()
-            .map(
-                message -> {
-                  // Allow list message headers in the expression
-                  switch (fieldName) {
-                    case "key":
-                      return message.getKey();
-                    case "topicName":
-                      return message.getTopicName();
-                    case "properties":
-                      return message.getProperties();
-                    case "producerName":
-                      return message.getProducerName();
-                    default:
-                      return null;
-                  }
-                })
-            .orElse(null);
+        // Allow list message headers in the expression
+        switch (fieldName) {
+          case "key":
+            return currentRecord.getKey().orElse(null);
+          case "topicName":
+            return currentRecord.getTopicName().orElse(null);
+          case "destinationTopic":
+            return currentRecord.getDestinationTopic().orElse(null);
+          case "eventTime":
+            return currentRecord.getEventTime().orElse(null);
+          case "properties":
+            return currentRecord.getProperties();
+          default:
+            return null;
+        }
       };
 
   private final Map<String, Object> lazyHeader =

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapter.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.predicate.jstl;
+
+import com.datastax.oss.pulsar.functions.transforms.TransformContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.map.LazyMap;
+import org.apache.pulsar.functions.api.Record;
+
+/**
+ * A java bean that adapts the underlying {@link TransformContext} to be ready for jstl expression
+ * language binding.
+ */
+public class JstlTransformContextAdapter {
+  private TransformContext transformContext;
+
+  /**
+   * A key transformer backing the lazy key map. It transforms top level key fields to either a
+   * value or another lazy map for nested evaluation.
+   */
+  private Transformer<String, Object> keyTransformer =
+      (fieldName) -> {
+        if (this.transformContext.getKeyObject() instanceof GenericRecord) {
+          GenericRecord genericRecord = (GenericRecord) this.transformContext.getKeyObject();
+          JstlPredicate.GenericRecordTransformer transformer =
+              new JstlPredicate.GenericRecordTransformer(genericRecord);
+          return transformer.transform(fieldName);
+        }
+        return null;
+      };
+
+  private final Map<String, Object> lazyKey = LazyMap.lazyMap(new HashMap<>(), keyTransformer);
+
+  /**
+   * A value transformer backing the lazy value map. It transforms top level value fields to either
+   * a value or another lazy map for nested evaluation.
+   */
+  private Transformer<String, Object> valueTransformer =
+      (fieldName) -> {
+        if (this.transformContext.getValueObject() instanceof GenericRecord) {
+          GenericRecord genericRecord = (GenericRecord) this.transformContext.getValueObject();
+          JstlPredicate.GenericRecordTransformer transformer =
+              new JstlPredicate.GenericRecordTransformer(genericRecord);
+          return transformer.transform(fieldName);
+        }
+        return null;
+      };
+
+  private final Map<String, Object> lazyValue = LazyMap.lazyMap(new HashMap<>(), valueTransformer);
+
+  /** A header transformer to return message headers the user is allowed to filter on. */
+  private Transformer<String, Object> headerTransformer =
+      (fieldName) -> {
+        Record<?> currentRecord = transformContext.getContext().getCurrentRecord();
+        return currentRecord
+            .getMessage()
+            .map(
+                message -> {
+                  // Allow list message headers in the expression
+                  switch (fieldName) {
+                    case "key":
+                      return message.getKey();
+                    case "topicName":
+                      return message.getTopicName();
+                    case "properties":
+                      return message.getProperties();
+                    case "producerName":
+                      return message.getProducerName();
+                    default:
+                      return null;
+                  }
+                })
+            .orElse(null);
+      };
+
+  private final Map<String, Object> lazyHeader =
+      LazyMap.lazyMap(new HashMap<>(), headerTransformer);
+
+  public JstlTransformContextAdapter(TransformContext transformContext) {
+    this.transformContext = transformContext;
+  }
+
+  public Map<String, Object> getKey() {
+    return lazyKey;
+  }
+
+  public Map<String, Object> getValue() {
+    return lazyValue;
+  }
+
+  public Map<String, Object> getHeader() {
+    return lazyHeader;
+  }
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapter.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.map.LazyMap;
-import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 
 /**
@@ -42,10 +41,6 @@ public class JstlTransformContextAdapter {
           JstlPredicate.GenericRecordTransformer transformer =
               new JstlPredicate.GenericRecordTransformer(genericRecord);
           return transformer.transform(fieldName);
-        } else if (this.transformContext.getKeyObject() instanceof KeyValue) {
-          KeyValue kv = (KeyValue) this.transformContext.getKeyObject();
-          JstlPredicate.KeyValueTransformer transformer = new JstlPredicate.KeyValueTransformer(kv);
-          return transformer.transform(fieldName);
         }
         return null;
       };
@@ -63,10 +58,6 @@ public class JstlTransformContextAdapter {
           JstlPredicate.GenericRecordTransformer transformer =
               new JstlPredicate.GenericRecordTransformer(genericRecord);
           return transformer.transform(fieldName);
-        } else if (this.transformContext.getValueObject() instanceof KeyValue) {
-          KeyValue kv = (KeyValue) this.transformContext.getValueObject();
-          JstlPredicate.KeyValueTransformer transformer = new JstlPredicate.KeyValueTransformer(kv);
-          return transformer.transform(fieldName);
         }
         return null;
       };
@@ -79,7 +70,7 @@ public class JstlTransformContextAdapter {
         Record<?> currentRecord = transformContext.getContext().getCurrentRecord();
         // Allow list message headers in the expression
         switch (fieldName) {
-          case "key":
+          case "messageKey":
             return currentRecord.getKey().orElse(null);
           case "topicName":
             return currentRecord.getTopicName().orElse(null);
@@ -102,29 +93,23 @@ public class JstlTransformContextAdapter {
   }
 
   /**
-   * @return either a lazily evaluated map to access top-level and nested fields on a generic object
-   *     or key value object, or the primitive type itself.
+   * @return either a lazily evaluated map to access top-level and nested fields on a generic
+   *     object, or the primitive type itself.
    */
   public Object getKey() {
-    if (this.transformContext.getKeyObject() instanceof GenericRecord
-        || this.transformContext.getKeyObject() instanceof KeyValue) {
-      return lazyKey;
-    } else {
-      return this.transformContext.getKeyObject();
-    }
+    return this.transformContext.getKeyObject() instanceof GenericRecord
+        ? lazyKey
+        : this.transformContext.getKeyObject();
   }
 
   /**
-   * @return either a lazily evaluated map to access top-level and nested fields on a generic object
-   *     or key value object , or the primitive type itself.
+   * @return either a lazily evaluated map to access top-level and nested fields on a generic
+   *     object, or the primitive type itself.
    */
   public Object getValue() {
-    if (this.transformContext.getValueObject() instanceof GenericRecord
-        || this.transformContext.getValueObject() instanceof KeyValue) {
-      return lazyValue;
-    } else {
-      return this.transformContext.getValueObject();
-    }
+    return this.transformContext.getValueObject() instanceof GenericRecord
+        ? lazyValue
+        : this.transformContext.getValueObject();
   }
 
   public Map<String, Object> getHeader() {

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
@@ -40,12 +40,19 @@ public class TransformFunctionTest {
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field'}]}"},
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 'key'}]}"},
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 'value'}]}"},
+      {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'when': 'key.k1=key1'}]}"},
       {"{'steps': [{'type': 'unwrap-key-value'}]}"},
       {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': false}]}"},
       {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': true}]}"},
+      {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': true, 'when': 'value.v1=val1'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'key'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'value'}]}"},
+      {"{'steps': [{'type': 'flatten'}]}"},
+      {"{'steps': [{'type': 'flatten', 'part': 'key'}]}"},
+      {"{'steps': [{'type': 'flatten', 'part': 'value'}]}"},
+      {"{'steps': [{'type': 'flatten', 'delimiter': '_'}]}"},
+      {"{'steps': [{'type': 'flatten', 'when': 'prop1=val1'}]}"},
     };
   }
 
@@ -70,11 +77,17 @@ public class TransformFunctionTest {
       {"{'steps': [{'type': 'drop-fields', 'fields': ''}]}"},
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 'invalid'}]}"},
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 42}]}"},
+      {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 42}]}"},
+      {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'when': '${'}]}"},
       {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': 'invalid'}]}"},
+      {"{'steps': [{'type': 'unwrap-key-value', 'when': '${'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 42}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'INVALID'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'invalid'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 42}]}"},
+      {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 42}], 'when': '${'}"},
+      {"{'steps': [{'type': 'flatten', 'part': 'invalid-part'}]}"},
+      {"{'steps': [{'type': 'flatten', 'when': '${'}]}"},
     };
   }
 
@@ -124,6 +137,90 @@ public class TransformFunctionTest {
     assertEquals(valueAvroRecord.get("valueField2"), new Utf8("value2"));
     assertNull(valueAvroRecord.getSchema().getField("valueField1"));
     assertNull(valueAvroRecord.getSchema().getField("valueField3"));
+  }
+
+  @Test
+  void testMatchingPredicate() throws Exception {
+    String userConfig =
+        (""
+            + "{\"steps\": ["
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"${key.keyField1 == 'key1'}\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField2\", \"when\": \"${key.keyField2 == 'key2'}\"}"
+            + "]}");
+    Map<String, Object> config =
+        new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+    TransformFunction transformFunction = new TransformFunction();
+
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    Utils.TestContext context = new Utils.TestContext(record, config);
+    transformFunction.initialize(context);
+    Record<GenericObject> outputRecord = transformFunction.process(record.getValue(), context);
+
+    KeyValueSchema messageSchema = (KeyValueSchema) outputRecord.getSchema();
+    KeyValue messageValue = (KeyValue) outputRecord.getValue();
+
+    GenericData.Record keyAvroRecord =
+        Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+    assertEquals(keyAvroRecord.get("keyField3"), new Utf8("key3"));
+    assertNull(keyAvroRecord.getSchema().getField("keyField1"));
+    assertNull(keyAvroRecord.getSchema().getField("keyField2"));
+  }
+
+  @Test
+  void testNonMatchingPredicate() throws Exception {
+    String userConfig =
+        (""
+            + "{\"steps\": ["
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"${key.keyField1 == 'key100'}\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField2\", \"when\": \"${key.keyField2 == 'key100'}\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField3\"}"
+            + "]}");
+    Map<String, Object> config =
+        new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+    TransformFunction transformFunction = new TransformFunction();
+
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    Utils.TestContext context = new Utils.TestContext(record, config);
+    transformFunction.initialize(context);
+    transformFunction.process(record.getValue(), context);
+
+    Record<GenericObject> outputRecord = transformFunction.process(record.getValue(), context);
+
+    KeyValueSchema messageSchema = (KeyValueSchema) outputRecord.getSchema();
+    KeyValue messageValue = (KeyValue) outputRecord.getValue();
+
+    GenericData.Record keyAvroRecord =
+        Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+    assertEquals(keyAvroRecord.get("keyField1"), new Utf8("key1"));
+    assertEquals(keyAvroRecord.get("keyField2"), new Utf8("key2"));
+    assertNull(keyAvroRecord.getSchema().getField("keyField3"));
+  }
+
+  @Test
+  void testMixedPredicate() throws Exception {
+    String userConfig =
+        (""
+            + "{\"steps\": ["
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"${key.keyField1 == 'key1'}\"},"
+            + "    {\"type\": \"merge-key-value\", \"when\": \"${key.keyField2 == 'key100'}\"},"
+            + "    {\"type\": \"unwrap-key-value\", \"when\": \"${key.keyField3 == 'key100'}\"},"
+            + "    {\"type\": \"cast\", \"schema-type\": \"STRING\", \"when\": \"${value.valueField1 == 'value1'}\"}"
+            + "]}");
+    Map<String, Object> config =
+        new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+    TransformFunction transformFunction = new TransformFunction();
+
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    Utils.TestContext context = new Utils.TestContext(record, config);
+    transformFunction.initialize(context);
+
+    Record<GenericObject> outputRecord = transformFunction.process(record.getValue(), context);
+
+    KeyValue<String, String> kv = (KeyValue<String, String>) outputRecord.getValue();
+    assertEquals(kv.getKey(), "{\"keyField2\": \"key2\", \"keyField3\": \"key3\"}");
+    assertEquals(
+        kv.getValue(),
+        "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}");
   }
 
   // TODO: just for demo. To be removed

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
@@ -40,11 +40,11 @@ public class TransformFunctionTest {
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field'}]}"},
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 'key'}]}"},
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 'value'}]}"},
-      {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'when': 'key.k1=key1'}]}"},
+      {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'when': 'key.k1==key1'}]}"},
       {"{'steps': [{'type': 'unwrap-key-value'}]}"},
       {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': false}]}"},
       {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': true}]}"},
-      {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': true, 'when': 'value.v1=val1'}]}"},
+      {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': true, 'when': 'value.v1==val1'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'key'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'value'}]}"},
@@ -52,7 +52,7 @@ public class TransformFunctionTest {
       {"{'steps': [{'type': 'flatten', 'part': 'key'}]}"},
       {"{'steps': [{'type': 'flatten', 'part': 'value'}]}"},
       {"{'steps': [{'type': 'flatten', 'delimiter': '_'}]}"},
-      {"{'steps': [{'type': 'flatten', 'when': 'prop1=val1'}]}"},
+      {"{'steps': [{'type': 'flatten', 'when': 'prop1==val1'}]}"},
     };
   }
 
@@ -78,16 +78,16 @@ public class TransformFunctionTest {
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 'invalid'}]}"},
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 42}]}"},
       {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'part': 42}]}"},
-      {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'when': '${'}]}"},
+      {"{'steps': [{'type': 'drop-fields', 'fields': 'some-field', 'when': ''}]}"},
       {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': 'invalid'}]}"},
-      {"{'steps': [{'type': 'unwrap-key-value', 'when': '${'}]}"},
+      {"{'steps': [{'type': 'unwrap-key-value', 'when': ''}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 42}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'INVALID'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'invalid'}]}"},
       {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 42}]}"},
-      {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 42}], 'when': '${'}"},
+      {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 42}], 'when': ''}"},
       {"{'steps': [{'type': 'flatten', 'part': 'invalid-part'}]}"},
-      {"{'steps': [{'type': 'flatten', 'when': '${'}]}"},
+      {"{'steps': [{'type': 'flatten', 'when': ''}]}"},
     };
   }
 
@@ -144,8 +144,8 @@ public class TransformFunctionTest {
     String userConfig =
         (""
             + "{\"steps\": ["
-            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"${key.keyField1 == 'key1'}\"},"
-            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField2\", \"when\": \"${key.keyField2 == 'key2'}\"}"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"key.keyField1 == 'key1'\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField2\", \"when\": \"key.keyField2 == 'key2'\"}"
             + "]}");
     Map<String, Object> config =
         new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
@@ -171,8 +171,8 @@ public class TransformFunctionTest {
     String userConfig =
         (""
             + "{\"steps\": ["
-            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"${key.keyField1 == 'key100'}\"},"
-            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField2\", \"when\": \"${key.keyField2 == 'key100'}\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"key.keyField1 == 'key100'\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField2\", \"when\": \"key.keyField2 == 'key100'\"},"
             + "    {\"type\": \"drop-fields\", \"fields\": \"keyField3\"}"
             + "]}");
     Map<String, Object> config =
@@ -201,10 +201,10 @@ public class TransformFunctionTest {
     String userConfig =
         (""
             + "{\"steps\": ["
-            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"${key.keyField1 == 'key1'}\"},"
-            + "    {\"type\": \"merge-key-value\", \"when\": \"${key.keyField2 == 'key100'}\"},"
-            + "    {\"type\": \"unwrap-key-value\", \"when\": \"${key.keyField3 == 'key100'}\"},"
-            + "    {\"type\": \"cast\", \"schema-type\": \"STRING\", \"when\": \"${value.valueField1 == 'value1'}\"}"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"keyField1\", \"when\": \"key.keyField1 == 'key1'\"},"
+            + "    {\"type\": \"merge-key-value\", \"when\": \"key.keyField2 == 'key100'\"},"
+            + "    {\"type\": \"unwrap-key-value\", \"when\": \"key.keyField3 == 'key100'\"},"
+            + "    {\"type\": \"cast\", \"schema-type\": \"STRING\", \"when\": \"value.valueField1 == 'value1'\"}"
             + "]}");
     Map<String, Object> config =
         new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicateTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicateTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.predicate.jstl;
+
+import static org.testng.AssertJUnit.assertTrue;
+
+import com.datastax.oss.pulsar.functions.transforms.TransformContext;
+import com.datastax.oss.pulsar.functions.transforms.Utils;
+import java.util.HashMap;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class JstlPredicateTest {
+
+  @Test(dataProvider = "jstlPredicates")
+  void testKeyScope(String when, boolean match) {
+    JstlPredicate predicate = new JstlPredicate(when);
+
+    Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(2);
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    assertTrue(predicate.test(transformContext) == match);
+  }
+
+  /** @return {"expression", "record", "expectedMatch"} */
+  @DataProvider(name = "jstlPredicates")
+  public static Object[][] jstlPredicates() {
+    return new Object[][] {
+      // match
+      {"${key.level1String == 'level1_1'}", true},
+      {"${key.level1Record.level2String == 'level2_1'}", true},
+      {"${key.level1Record.level2Integer == 9}", true},
+      {"${key.level1Record.level2Double == 8.8}", true},
+      {"${value.level1String.contains('level1')}", true},
+      {"${value.level1Record.level2String.toUpperCase() == 'LEVEL2_1'}", true},
+      {"${value.level1Record.level2Integer > 8}", true},
+      {"${value.level1Record.level2Double < 8.9}", true},
+      {"${header.key == 'key-1'}", true},
+      {"${header.producerName == 'producer-1'}", true},
+      {"${header.topicName == 'topic-1'}", true},
+      {"${header.properties.p1 == 'v1'}", true},
+      {"${header.properties.p2 == 'v2'}", true},
+      // no match
+      {"${key.level1String == 'leVel1_1'}", false},
+      {"${key.level1Record.random == 'level2_1'}", false},
+      {"${key.level1Record.level2Integer != 9}", false},
+      {"${key.level1Record.level2Double < 8.8}", false},
+      {"${value.level1String.contains('level2')}", false},
+      {"${value.level1Record.level2String.toUpperCase() == 'LeVEL2_1'}", false},
+      {"${value.level1Record.level2Integer > 10}", false},
+      {"${value.level1Record.level2Double < 0}", false},
+      {"${header.key == 'key1'}", false},
+      {"${header.producerNames == 'producer-1'}", false},
+      {"${header.topicName != 'topic-1'}", false},
+      {"${header.properties.p1.substring(0,1) == 'v1'}", false},
+      {"${header.properties.p2 == 'v3'}", false},
+      // complex
+      {
+        "${key.level1String == 'level1_1' && key.level1Record.level2String == 'level2_1' && "
+            + " key.level1Record.level2Integer == 9 && key.level1Record.level2Double == 8.8 && "
+            + "value.level1String.contains('level1')}",
+        true
+      },
+      {
+        "${key.level1String == 'level1_1' || key.level1Record.level2String == 'random' || "
+            + " key.level1Record.level2Integer == 5 || key.level1Record.level2Double != 8.8 || "
+            + "value.level1String.contains('level1')}",
+        true
+      },
+      {
+        "${key.level1String == 'level1_1' && key.level1Record.level2String == 'level2_1' && "
+            + " key.level1Record.level2Integer == 9} && key.level1Record.level2Double != 8.8} && "
+            + "value.level1String.contains('level1')}",
+        false
+      },
+    };
+  }
+}

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicateTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicateTest.java
@@ -20,15 +20,21 @@ import static org.testng.AssertJUnit.assertTrue;
 import com.datastax.oss.pulsar.functions.transforms.TransformContext;
 import com.datastax.oss.pulsar.functions.transforms.Utils;
 import java.util.HashMap;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class JstlPredicateTest {
 
-  @Test(dataProvider = "jstlPredicates")
-  void testJstlPredicates(String when, boolean match) {
+  @Test(dataProvider = "keyValuePredicates")
+  void testKeyValueAvro(String when, boolean match) {
     JstlPredicate predicate = new JstlPredicate(when);
 
     Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(2);
@@ -39,9 +45,277 @@ public class JstlPredicateTest {
     assertTrue(predicate.test(transformContext) == match);
   }
 
-  /** @return {"expression", "record", "expectedMatch"} */
-  @DataProvider(name = "jstlPredicates")
-  public static Object[][] jstlPredicates() {
+  @Test(dataProvider = "primitiveKeyValuePredicates")
+  void testPrimitiveKeyValueAvro(String when, TransformContext context, boolean match) {
+    JstlPredicate predicate = new JstlPredicate(when);
+    assertTrue(predicate.test(context) == match);
+  }
+
+  @Test(dataProvider = "nestedKeyValuePredicates")
+  void testNestedKeyValueAvro(String when, TransformContext context, boolean match) {
+    JstlPredicate predicate = new JstlPredicate(when);
+    assertTrue(predicate.test(context) == match);
+  }
+
+  @Test(dataProvider = "nestedGenericKeyValuePredicates")
+  void testNestedGenericKeyValueAvro(String when, TransformContext context, boolean match) {
+    JstlPredicate predicate = new JstlPredicate(when);
+    assertTrue(predicate.test(context) == match);
+  }
+
+  @Test(dataProvider = "primitivePredicates")
+  void testPrimitiveValueAvro(String when, TransformContext context, boolean match) {
+    JstlPredicate predicate = new JstlPredicate(when);
+    assertTrue(predicate.test(context) == match);
+  }
+
+  /** @return {"expression", "transform context" "expected match boolean"} */
+  @DataProvider(name = "primitiveKeyValuePredicates")
+  public static Object[][] primitiveKeyValuePredicates() {
+    Schema<KeyValue<String, Integer>> keyValueSchema =
+        Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+    KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+    Record<GenericObject> primitiveKVRecord =
+        new Utils.TestRecord<>(
+            keyValueSchema,
+            AutoConsumeSchema.wrapPrimitiveObject(keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+            null);
+
+    TransformContext primitiveKVContext =
+        new TransformContext(
+            new Utils.TestContext(primitiveKVRecord, new HashMap<>()),
+            primitiveKVRecord.getValue().getNativeObject());
+
+    return new Object[][] {
+      // match
+      {"key=='key' && value==42", primitiveKVContext, true},
+      // no-match
+      {"key=='key' && value<42", primitiveKVContext, false},
+    };
+  }
+
+  /** @return {"expression", "transform context" "expected match boolean"} */
+  @DataProvider(name = "primitivePredicates")
+  public static Object[][] primitivePredicates() {
+    Record<GenericObject> primitiveStringRecord =
+        new Utils.TestRecord<>(
+            Schema.STRING,
+            AutoConsumeSchema.wrapPrimitiveObject("test-message", SchemaType.STRING, new byte[] {}),
+            "header-key");
+    TransformContext primitiveStringContext =
+        new TransformContext(
+            new Utils.TestContext(primitiveStringRecord, new HashMap<>()),
+            primitiveStringRecord.getValue().getNativeObject());
+
+    Record<GenericObject> primitiveIntRecord =
+        new Utils.TestRecord<>(
+            Schema.INT32,
+            AutoConsumeSchema.wrapPrimitiveObject(33, SchemaType.INT32, new byte[] {}),
+            "header-key");
+    TransformContext primitiveIntContext =
+        new TransformContext(
+            new Utils.TestContext(primitiveIntRecord, new HashMap<>()),
+            primitiveIntRecord.getValue().getNativeObject());
+
+    Schema<KeyValue<String, Integer>> keyValueSchema =
+        Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+    KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+    Record<GenericObject> primitiveKVRecord =
+        new Utils.TestRecord<>(
+            keyValueSchema,
+            AutoConsumeSchema.wrapPrimitiveObject(keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+            "header-key");
+
+    TransformContext primitiveKVContext =
+        new TransformContext(
+            new Utils.TestContext(primitiveKVRecord, new HashMap<>()),
+            primitiveKVRecord.getValue().getNativeObject());
+
+    return new Object[][] {
+      // match
+      {"value=='test-message'", primitiveStringContext, true},
+      {"value.contains('test')", primitiveStringContext, true},
+      {"header.key=='header-key'", primitiveStringContext, true},
+      {"value==33", primitiveIntContext, true},
+      {"value>32", primitiveIntContext, true},
+      {"value<=33 && header.key=='header-key'", primitiveIntContext, true},
+      {"key=='key' && value==42", primitiveKVContext, true},
+      {"key=='key' && header.key=='header-key'", primitiveKVContext, true},
+      // no-match
+      {"value=='test-message-'", primitiveStringContext, false},
+      {"value.contains('random')", primitiveStringContext, false},
+      {"header.key!='header-key'", primitiveStringContext, false},
+      {"value==34", primitiveIntContext, false},
+      {"value>33", primitiveIntContext, false},
+      {"value<=20 && header.key=='test-key'", primitiveIntContext, false},
+    };
+  }
+
+  /** @return {"expression", "transform context" "expected match boolean"} */
+  @DataProvider(name = "nestedKeyValuePredicates")
+  public static Object[][] nestedKeyValuePredicates() {
+    Schema<KeyValue<String, Integer>> keyValueSchema =
+        Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+    Schema<KeyValue<KeyValue<String, Integer>, Integer>> nestedKeySchema =
+        Schema.KeyValue(keyValueSchema, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+    KeyValue<String, Integer> keyValue = new KeyValue<>("key1", 42);
+
+    KeyValue<KeyValue<String, Integer>, Integer> nestedKeyKV = new KeyValue<>(keyValue, 3);
+
+    GenericObject genericNestedKeyObject =
+        new GenericObject() {
+          @Override
+          public SchemaType getSchemaType() {
+            return SchemaType.KEY_VALUE;
+          }
+
+          @Override
+          public Object getNativeObject() {
+            return nestedKeyKV;
+          }
+        };
+
+    Record<GenericObject> nestedKeyRecord =
+        new Utils.TestRecord<>(nestedKeySchema, genericNestedKeyObject, null);
+
+    TransformContext nestedKeyContext =
+        new TransformContext(
+            new Utils.TestContext(nestedKeyRecord, new HashMap<>()),
+            nestedKeyRecord.getValue().getNativeObject());
+
+    Schema<KeyValue<String, KeyValue<String, Integer>>> nestedValueSchema =
+        Schema.KeyValue(Schema.STRING, keyValueSchema, KeyValueEncodingType.SEPARATED);
+
+    KeyValue<String, KeyValue<String, Integer>> nestedValueKV = new KeyValue<>("key1", keyValue);
+
+    GenericObject genericNestedValueObject =
+        new GenericObject() {
+          @Override
+          public SchemaType getSchemaType() {
+            return SchemaType.KEY_VALUE;
+          }
+
+          @Override
+          public Object getNativeObject() {
+            return nestedValueKV;
+          }
+        };
+
+    Record<GenericObject> nestedValueRecord =
+        new Utils.TestRecord<>(nestedValueSchema, genericNestedValueObject, null);
+
+    TransformContext nestedValueContext =
+        new TransformContext(
+            new Utils.TestContext(nestedValueRecord, new HashMap<>()),
+            nestedValueRecord.getValue().getNativeObject());
+    return new Object[][] {
+      // match
+      {"key.key=='key1'", nestedKeyContext, true},
+      {"key.value==42", nestedKeyContext, true},
+      {"value==3", nestedKeyContext, true},
+      {"value.key=='key1'", nestedValueContext, true},
+      {"value.value==42", nestedValueContext, true},
+      {"key=='key1'", nestedValueContext, true},
+      // no match
+      {"key.key=='key2'", nestedKeyContext, false},
+      {"key.value<42", nestedKeyContext, false},
+      {"value==4", nestedKeyContext, false},
+      {"value.key=='key2'", nestedValueContext, false},
+      {"value.value<42", nestedValueContext, false},
+      {"key=='key2'", nestedValueContext, false},
+    };
+  }
+
+  /** @return {"expression", "transform context" "expected match boolean"} */
+  @DataProvider(name = "nestedGenericKeyValuePredicates")
+  public static Object[][] nestedGenericKeyValuePredicates() {
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    Schema<KeyValue<KeyValue<GenericObject, GenericObject>, Integer>> nestedKeySchema =
+        Schema.KeyValue(
+            (KeyValueSchema) record.getSchema(), Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+    KeyValue<KeyValue<GenericObject, GenericObject>, Integer> nestedKeyKV =
+        new KeyValue<>(
+            (KeyValue<GenericObject, GenericObject>) record.getValue().getNativeObject(), 3);
+
+    GenericObject genericNestedKeyObject =
+        new GenericObject() {
+          @Override
+          public SchemaType getSchemaType() {
+            return SchemaType.KEY_VALUE;
+          }
+
+          @Override
+          public Object getNativeObject() {
+            return nestedKeyKV;
+          }
+        };
+
+    Record<GenericObject> nestedKeyRecord =
+        new Utils.TestRecord<>(nestedKeySchema, genericNestedKeyObject, null);
+
+    TransformContext nestedKeyContext =
+        new TransformContext(
+            new Utils.TestContext(nestedKeyRecord, new HashMap<>()),
+            nestedKeyRecord.getValue().getNativeObject());
+
+    Schema<KeyValue<Integer, KeyValue<GenericObject, GenericObject>>> nestedValueSchema =
+        Schema.KeyValue(
+            Schema.INT32, (KeyValueSchema) record.getSchema(), KeyValueEncodingType.SEPARATED);
+
+    KeyValue<Integer, KeyValue<GenericObject, GenericObject>> nestedValueKV =
+        new KeyValue<>(
+            3, (KeyValue<GenericObject, GenericObject>) record.getValue().getNativeObject());
+
+    GenericObject genericNestedValueObject =
+        new GenericObject() {
+          @Override
+          public SchemaType getSchemaType() {
+            return SchemaType.KEY_VALUE;
+          }
+
+          @Override
+          public Object getNativeObject() {
+            return nestedValueKV;
+          }
+        };
+
+    Record<GenericObject> nestedValueRecord =
+        new Utils.TestRecord<>(nestedValueSchema, genericNestedValueObject, null);
+
+    TransformContext nestedValueContext =
+        new TransformContext(
+            new Utils.TestContext(nestedValueRecord, new HashMap<>()),
+            nestedValueRecord.getValue().getNativeObject());
+
+    return new Object[][] {
+      // match
+      {"key.key.keyField1=='key1'", nestedKeyContext, true},
+      {"key.value.valueField1=='value1'", nestedKeyContext, true},
+      {"value==3", nestedKeyContext, true},
+      {"value.key.keyField1=='key1'", nestedValueContext, true},
+      {"value.value.valueField1=='value1'", nestedValueContext, true},
+      {"key==3", nestedValueContext, true},
+
+      // no match
+      {"key.key.keyField999=='key1'", nestedKeyContext, false},
+      {"key.value.valueField999=='value1'", nestedKeyContext, false},
+      {"value==4", nestedKeyContext, false},
+      {"value.key.keyField999=='key1'", nestedValueContext, false},
+      {"value.value.valueField999=='value1'", nestedValueContext, false},
+      {"key==4", nestedValueContext, false},
+    };
+  }
+
+  /** @return {"expression", "expected match boolean"} */
+  @DataProvider(name = "keyValuePredicates")
+  public static Object[][] keyValuePredicates() {
     return new Object[][] {
       // match
       {"key.level1String == 'level1_1'", true},

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicateTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlPredicateTest.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 public class JstlPredicateTest {
 
   @Test(dataProvider = "jstlPredicates")
-  void testKeyScope(String when, boolean match) {
+  void testJstlPredicates(String when, boolean match) {
     JstlPredicate predicate = new JstlPredicate(when);
 
     Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(2);
@@ -44,50 +44,58 @@ public class JstlPredicateTest {
   public static Object[][] jstlPredicates() {
     return new Object[][] {
       // match
-      {"${key.level1String == 'level1_1'}", true},
-      {"${key.level1Record.level2String == 'level2_1'}", true},
-      {"${key.level1Record.level2Integer == 9}", true},
-      {"${key.level1Record.level2Double == 8.8}", true},
-      {"${value.level1String.contains('level1')}", true},
-      {"${value.level1Record.level2String.toUpperCase() == 'LEVEL2_1'}", true},
-      {"${value.level1Record.level2Integer > 8}", true},
-      {"${value.level1Record.level2Double < 8.9}", true},
-      {"${header.key == 'key-1'}", true},
-      {"${header.producerName == 'producer-1'}", true},
-      {"${header.topicName == 'topic-1'}", true},
-      {"${header.properties.p1 == 'v1'}", true},
-      {"${header.properties.p2 == 'v2'}", true},
+      {"key.level1String == 'level1_1'", true},
+      {"key.level1Record.level2String == 'level2_1'", true},
+      {"key.level1Record.level2Integer == 9", true},
+      {"key.level1Record.level2Double == 8.8", true},
+      {"value.level1String.contains('level1')", true},
+      {"value.level1Record.level2String.toUpperCase() == 'LEVEL2_1'", true},
+      {"value.level1Record.level2Integer > 8", true},
+      {"value.level1Record.level2Double < 8.9", true},
+      {"header.key == 'key1'", true},
+      {"header.destinationTopic == 'dest-topic-1'", true},
+      {"header.topicName == 'topic-1'", true},
+      {"header.properties.p1 == 'v1'", true},
+      {"header.properties.p2 == 'v2'", true},
       // no match
-      {"${key.level1String == 'leVel1_1'}", false},
-      {"${key.level1Record.random == 'level2_1'}", false},
-      {"${key.level1Record.level2Integer != 9}", false},
-      {"${key.level1Record.level2Double < 8.8}", false},
-      {"${value.level1String.contains('level2')}", false},
-      {"${value.level1Record.level2String.toUpperCase() == 'LeVEL2_1'}", false},
-      {"${value.level1Record.level2Integer > 10}", false},
-      {"${value.level1Record.level2Double < 0}", false},
-      {"${header.key == 'key1'}", false},
-      {"${header.producerNames == 'producer-1'}", false},
-      {"${header.topicName != 'topic-1'}", false},
-      {"${header.properties.p1.substring(0,1) == 'v1'}", false},
-      {"${header.properties.p2 == 'v3'}", false},
+      {"key.level1String == 'leVel1_1'", false},
+      {"key.level1Record.random == 'level2_1'", false},
+      {"key.level1Record.level2Integer != 9", false},
+      {"key.level1Record.level2Double < 8.8", false},
+      {"key.randomKey == 'k1'", false},
+      {"value.level1String.contains('level2')", false},
+      {"value.level1Record.level2String.toUpperCase() == 'LeVEL2_1'", false},
+      {"value.level1Record.level2Integer > 10", false},
+      {"value.level1Record.level2Double < 0", false},
+      {"value.randomValue < 0", false},
+      {"header.key == 'key2'", false},
+      {"header.outputTopicName == 'output-topic-1'", false},
+      {"header.topicName != 'topic-1'", false},
+      {"header.properties.p1.substring(0,1) == 'v1'", false},
+      {"header.properties.p2 == 'v3'", false},
+      {"header.randomHeader == 'h1'", false},
       // complex
       {
-        "${key.level1String == 'level1_1' && key.level1Record.level2String == 'level2_1' && "
-            + " key.level1Record.level2Integer == 9 && key.level1Record.level2Double == 8.8 && "
-            + "value.level1String.contains('level1')}",
+        "header.properties.p1.toUpperCase() == 'V1' && header.key == 'key1' && header.topicName == 'topic-1' && "
+            + "header.destinationTopic == 'dest-topic-1'",
         true
       },
       {
-        "${key.level1String == 'level1_1' || key.level1Record.level2String == 'random' || "
+        "key.level1String == 'level1_1' || key.level1Record.level2String == 'random' || "
             + " key.level1Record.level2Integer == 5 || key.level1Record.level2Double != 8.8 || "
-            + "value.level1String.contains('level1')}",
+            + "value.level1String.contains('level1')",
         true
       },
       {
-        "${key.level1String == 'level1_1' && key.level1Record.level2String == 'level2_1' && "
-            + " key.level1Record.level2Integer == 9} && key.level1Record.level2Double != 8.8} && "
-            + "value.level1String.contains('level1')}",
+        "key.level1String == 'level1_1' && key.level1Record.level2String == 'level2_1' && "
+            + " key.level1Record.level2Integer == 9 && key.level1Record.level2Double != 8.8} && "
+            + "value.level1String.contains('level1')",
+        false
+      },
+      {
+        "key.level1String == 'level1_1' && key.level1Record.level2String == 'level2_1' && "
+            + " key.level1Record.level2Integer == 9 && key.level1Record.level2Double != 8.8} && "
+            + "value.level1String.contains('level1')",
         false
       },
     };

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapterTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.predicate.jstl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.datastax.oss.pulsar.functions.transforms.TransformContext;
+import com.datastax.oss.pulsar.functions.transforms.Utils;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class JstlTransformContextAdapterTest {
+  @Test
+  void testAdapterForKeyValueRecord() {
+    // given
+    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+    /**
+     * Actual key: { "keyField1": "key1", "keyField2": "key2", "keyField3": "key3" }
+     *
+     * <p>Actual value: { "valueField1": "value1", "valueField2": "value2", "valueField3": "value3"
+     * }
+     */
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    // when
+    JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+    // then
+    assertEquals(adapter.getKey().get("keyField1"), "key1");
+    assertEquals(adapter.getKey().get("keyField2"), "key2");
+    assertEquals(adapter.getKey().get("keyField3"), "key3");
+    assertNull(adapter.getKey().get("keyField4"));
+
+    assertEquals(adapter.getValue().get("valueField1"), "value1");
+    assertEquals(adapter.getValue().get("valueField2"), "value2");
+    assertEquals(adapter.getValue().get("valueField3"), "value3");
+    assertNull(adapter.getKey().get("valueField4"));
+  }
+
+  @Test
+  void testAdapterForPrimitiveRecord() {
+    // given
+    Record<GenericObject> record =
+        new Utils.TestRecord<>(
+            Schema.STRING,
+            AutoConsumeSchema.wrapPrimitiveObject("test-message", SchemaType.STRING, new byte[] {}),
+            "test-key");
+    /** Actual key: "test-key" Actual value: "test-message" */
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    // when
+    JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+    // then
+    assertEquals(adapter.getHeader().get("key"), "test-key");
+    assertNull(adapter.getKey().get("key"));
+    assertNull(adapter.getKey().get("level1String"));
+    assertNull(adapter.getKey().get("level1Record"));
+    assertNull(adapter.getValue().get("value"));
+    assertNull(adapter.getValue().get("level1String"));
+    assertNull(adapter.getValue().get("level1Record"));
+  }
+
+  @Test
+  void testAdapterForNestedValueRecord() {
+    // given
+    Record<GenericObject> record = Utils.createNestedAvroRecord(4, "header-key");
+    /**
+     * Actual key: "header-key"
+     *
+     * <p>Actual value: "level1String": "level1_1", "level1Record": { "level2String": "level2_1",
+     * "level2Record": { "level3String": "level3_1", "level3Record": { "level4String": "level4_1",
+     * "level4Integer": 9, "level4Double": 8.8, "level4StringWithProps": "level4_WithProps",
+     * "level4Union": "level4_2" } } } }
+     */
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    // when
+    JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+    // then
+    assertEquals(adapter.getHeader().get("key"), "header-key");
+    assertNull(adapter.getKey().get("key"));
+    assertNull(adapter.getKey().get("level1String"));
+    assertNull(adapter.getKey().get("level1Record"));
+    assertNestedRecord(adapter.getValue());
+  }
+
+  @Test
+  void testAdapterForNestedKeyValueRecord() {
+    // given
+    Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(4);
+    /**
+     * Actual key: { "level1String": "level1_1", "level1Record": { "level2String": "level2_1",
+     * "level2Record": { "level3String": "level3_1", "level3Record": { "level4String": "level4_1",
+     * "level4Integer": 9, "level4Double": 8.8, "level4StringWithProps": "level4_WithProps",
+     * "level4Union": "level4_2" } } } }
+     *
+     * <p>Actual value: "level1String": "level1_1", "level1Record": { "level2String": "level2_1",
+     * "level2Record": { "level3String": "level3_1", "level3Record": { "level4String": "level4_1",
+     * "level4Integer": 9, "level4Double": 8.8, "level4StringWithProps": "level4_WithProps",
+     * "level4Union": "level4_2" } } } }
+     */
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    // when
+    JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+    // then
+    assertNestedRecord(adapter.getKey());
+    assertNestedRecord(adapter.getValue());
+  }
+
+  @Test
+  void testAdapterForRecordHeaders() {
+    // given
+    Map<String, String> props = new HashMap<>();
+    props.put("p1", "v1");
+    props.put("p2", "v2");
+    Record<GenericObject> record =
+        Utils.TestRecord.<GenericObject>builder()
+            .schema(Schema.STRING)
+            .value(
+                AutoConsumeSchema.wrapPrimitiveObject(
+                    "test-message", SchemaType.STRING, new byte[] {}))
+            .key("test-key")
+            .topicName("test-topic")
+            .destinationTopic("test-dest-topic")
+            .eventTime(1662493532L)
+            .properties(props)
+            .build();
+
+    Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+    TransformContext transformContext =
+        new TransformContext(context, record.getValue().getNativeObject());
+
+    // when
+    JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+    // then
+    assertEquals(adapter.getHeader().get("key"), "test-key");
+    assertEquals(adapter.getHeader().get("topicName"), "test-topic");
+    assertEquals(adapter.getHeader().get("destinationTopic"), "test-dest-topic");
+    assertEquals(adapter.getHeader().get("eventTime"), 1662493532L);
+    assertTrue(adapter.getHeader().get("properties") instanceof Map);
+    Map headerProps = (Map) adapter.getHeader().get("properties");
+    assertEquals(headerProps.get("p1"), "v1");
+    assertEquals(headerProps.get("p2"), "v2");
+    assertNull(headerProps.get("p3"));
+  }
+
+  void assertNestedRecord(Map root) {
+    assertTrue(root.get("level1Record") instanceof Map);
+    Map l1Map = (Map) root.get("level1Record");
+    assertEquals(l1Map.get("level2String"), "level2_1");
+
+    assertTrue(l1Map.get("level2Record") instanceof Map);
+    Map l2Map = (Map) l1Map.get("level2Record");
+    assertEquals(l2Map.get("level3String"), "level3_1");
+
+    assertTrue(l2Map.get("level3Record") instanceof Map);
+    Map l3Map = (Map) l2Map.get("level3Record");
+    assertEquals(l3Map.get("level4String"), "level4_1");
+    assertEquals(l3Map.get("level4Integer"), 9);
+    assertEquals(l3Map.get("level4Double"), 8.8D);
+
+    assertNull(l3Map.get("level4Record"));
+  }
+}

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlTransformContextAdapterTest.java
@@ -90,7 +90,7 @@ public class JstlTransformContextAdapterTest {
 
     assertEquals(adapter.getKey(), "key");
     assertEquals(adapter.getValue(), 42);
-    assertEquals(adapter.getHeader().get("key"), "header-key");
+    assertEquals(adapter.getHeader().get("messageKey"), "header-key");
   }
 
   @Test
@@ -110,7 +110,7 @@ public class JstlTransformContextAdapterTest {
     JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
 
     // then
-    assertEquals(adapter.getHeader().get("key"), "header-key");
+    assertEquals(adapter.getHeader().get("messageKey"), "header-key");
     assertNull(adapter.getKey());
 
     assertEquals(adapter.getValue(), "test-message");
@@ -137,7 +137,7 @@ public class JstlTransformContextAdapterTest {
     JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
 
     // then
-    assertEquals(adapter.getHeader().get("key"), "header-key");
+    assertEquals(adapter.getHeader().get("messageKey"), "header-key");
     assertNull(adapter.getKey());
     assertTrue(adapter.getValue() instanceof Map);
     Map valueMap = (Map<String, Object>) adapter.getValue();
@@ -201,7 +201,7 @@ public class JstlTransformContextAdapterTest {
     JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
 
     // then
-    assertEquals(adapter.getHeader().get("key"), "test-key");
+    assertEquals(adapter.getHeader().get("messageKey"), "test-key");
     assertEquals(adapter.getHeader().get("topicName"), "test-topic");
     assertEquals(adapter.getHeader().get("destinationTopic"), "test-dest-topic");
     assertEquals(adapter.getHeader().get("eventTime"), 1662493532L);

--- a/tests/src/test/java/com/datastax/oss/pulsar/functions/transforms/tests/AbstractDockerTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/functions/transforms/tests/AbstractDockerTest.java
@@ -164,6 +164,27 @@ public abstract class AbstractDockerTest {
     assertEquals(keyValue.getValue().getNativeObject().toString(), "{\"d\": \"d\"}");
   }
 
+  @Test
+  public void testOutputKVAvroWhen() throws Exception {
+    String userConfig =
+        (""
+            + "{\"steps\": ["
+            + "    {\"type\": \"drop-fields\", \"fields\": \"a\", \"when\": \"key.a=='a'\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"b\", \"when\": \"key.b!='b'\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"c\", \"when\": \"value.c=='c'\"},"
+            + "    {\"type\": \"drop-fields\", \"fields\": \"d\", \"when\": \"value.d!='d'\"}"
+            + "]}");
+    GenericRecord value = testTransformFunction(userConfig);
+    assertEquals(value.getSchemaType(), SchemaType.KEY_VALUE);
+    KeyValue<GenericObject, GenericObject> keyValue =
+        (KeyValue<GenericObject, GenericObject>) value.getNativeObject();
+
+    assertEquals(keyValue.getKey().getSchemaType(), SchemaType.AVRO);
+    assertEquals(keyValue.getKey().getNativeObject().toString(), "{\"b\": \"b\"}");
+    assertEquals(keyValue.getValue().getSchemaType(), SchemaType.AVRO);
+    assertEquals(keyValue.getValue().getNativeObject().toString(), "{\"d\": \"d\"}");
+  }
+
   private GenericRecord testTransformFunction(String userConfig)
       throws PulsarAdminException, InterruptedException,
           org.apache.pulsar.client.api.PulsarClientException {
@@ -193,7 +214,7 @@ public abstract class AbstractDockerTest {
     admin.functions().createFunction(functionConfig, null);
 
     FunctionStatus functionStatus = null;
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 300; i++) {
       functionStatus = admin.functions().getFunctionStatus("public", "default", functionName);
       if (functionStatus.getNumRunning() == 1) {
         break;

--- a/tests/src/test/java/com/datastax/oss/pulsar/functions/transforms/tests/AbstractDockerTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/functions/transforms/tests/AbstractDockerTest.java
@@ -33,7 +33,6 @@ import static org.testng.Assert.fail;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
This is a Unified Expression Language (EL) based step predicates implementation. Please check #6 for comparison with JMS based 
filter implementation. A sample when condition would be:

`${key.field1 == 'value' && key.recordField.field2.toUpperCase == 'VALUE2"`

Few implementation details:
* Each step has an option `when` config. It is written in the EL defined [here](https://javaee.github.io/tutorial/jsf-el001.html#BNAHQ)
* The chosen java implementation of the EL is [JUEL](https://github.com/beckchr/juel)
* The language natively supports nested props access via the dot notation. 
* In order to generate bindings for the fields in the expression, and given the dynamic nature of our generic records and k/v schema, a lazy map is initialized with an adapter object to expose parts of the TransformContext as request by the expression evaluater. Note that an alternative to this would've been to generate java beans props dynamically at runtime (seems possible via spring's [BeanDefinitionRegistryPostProcessor](https://docs.spring.io/spring-framework/docs/3.0.x/javadoc-api/org/springframework/beans/factory/support/BeanDefinitionRegistryPostProcessor.html) 
* The user can choose between 2 different scopes : `[key, value]`. Header fields are avaible as top level attributes like`topicName`. Please note that the header `key` (aka. the partition key) is called `messageKey` to avoid conflict with an INLINE KV key if one exists
* The user defined props can be accessed via `${header.properties.propertyName}` syntax
* Header props are enabled on an `allowlisting` bases so we have control over which headers are included the headers. 
* Adding new predicate types (if needed, say we want to give our users flexibility to choose between jstl and jms Language), an implementation of the `TransformPredicate` is all what's needed. The a factory

If this is the right direction (vs the JMS one) - I'll use this PR as basis for the final implementation (mainly adding more test coverage) 
