### PR TITLE
Implement drop transform step

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/DropStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/DropStep.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+/**
+ * Drops a message from further processing. Works in conjunctions with predicates to selectively
+ * choose which messages to drop
+ */
+public class DropStep implements TransformStep {
+  @Override
+  public void process(TransformContext transformContext) throws Exception {
+    transformContext.setDropCurrentRecord(true);
+  }
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformContext.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformContext.java
@@ -48,6 +48,7 @@ public class TransformContext {
   private String key;
   private Map<String, String> properties;
   private String outputTopic;
+  private boolean dropCurrentRecord;
 
   public TransformContext(Context context, Object value) {
     Record<?> currentRecord = context.getCurrentRecord();
@@ -76,6 +77,9 @@ public class TransformContext {
   }
 
   public Record<GenericObject> send() throws IOException {
+    if (dropCurrentRecord) {
+      return null;
+    }
     if (keyModified
         && keySchema != null
         && keySchema.getSchemaInfo().getType() == SchemaType.AVRO) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -60,6 +60,8 @@ import org.apache.pulsar.functions.api.Record;
  *       level fields. <code>
  *       delimiter</code> defaults to '_'. <code>part</code> could be any of <code>key</code> or
  *       <code>value</code>. If not specified, flatten will apply to key and value.
+ *   <li><code>drop</code>: drops the message from further processing. Use in conjunction with
+ *       <code>when</code> to selectively drop messages.
  * </ul>
  *
  * <p>The <code>TransformFunction</code> reads its configuration as Json from the {@link Context}
@@ -82,6 +84,9 @@ import org.apache.pulsar.functions.api.Record;
  *     },
  *     {
  *       "type": "flatten", "delimiter" : "_" "part" : "value", "when": "value.field == 'value'"
+ *     },
+ *     {
+ *       "type": "drop", "when": "value.field == 'value'"
  *     }
  *   ]
  * }
@@ -130,6 +135,9 @@ public class TransformFunction
           break;
         case "flatten":
           transformStep = newFlattenFunction(step);
+          break;
+        case "drop":
+          transformStep = new DropStep();
           break;
         default:
           throw new IllegalArgumentException("invalid step type: " + type);

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/DropTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/DropTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import static org.testng.Assert.assertNull;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class DropTest {
+
+  @Test
+  void testAvro() throws Exception {
+    RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+    recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+
+    SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+    GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+    GenericRecord genericRecord = genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+
+    Record<GenericObject> record = new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+    DropStep step = new DropStep();
+    Record<?> outputRecord = Utils.process(record, step);
+    assertNull(outputRecord);
+  }
+
+  @Test
+  void testKeyValueAvro() throws Exception {
+    DropStep step = new DropStep();
+    Record<?> outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
+    assertNull(outputRecord);
+  }
+
+  @Test
+  void testPrimitives() throws Exception {
+    Record<GenericObject> record =
+        new Utils.TestRecord<>(
+            Schema.STRING,
+            AutoConsumeSchema.wrapPrimitiveObject("value", SchemaType.STRING, new byte[] {}),
+            "test-key");
+
+    DropStep step = new DropStep();
+    Record<?> outputRecord = Utils.process(record, step);
+    assertNull(outputRecord);
+  }
+
+  @Test
+  void testKeyValuePrimitives() throws Exception {
+    Schema<KeyValue<String, Integer>> keyValueSchema =
+        Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+    KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+    Record<GenericObject> record =
+        new Utils.TestRecord<>(
+            keyValueSchema,
+            AutoConsumeSchema.wrapPrimitiveObject(keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+            null);
+
+    DropStep step = new DropStep();
+    Record<?> outputRecord = Utils.process(record, step);
+    assertNull(outputRecord);
+  }
+}

--- a/tests/src/test/java/com/datastax/oss/pulsar/functions/transforms/tests/AbstractDockerTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/functions/transforms/tests/AbstractDockerTest.java
@@ -246,8 +246,7 @@ public abstract class AbstractDockerTest {
 
   @Test
   void testDropMessageOnPredicateMatch() throws Exception {
-    String userConfig =
-        ("" + "{\"steps\": [" + "    {\"type\": \"drop\", \"when\": \"value.a=='a'\"}" + "]}");
+    String userConfig = "{\"steps\": [{\"type\": \"drop\", \"when\": \"value.a=='a'\"}]}";
     GenericRecord value =
         testTransformFunction(
             userConfig, Schema.AVRO(Pojo1.class), new Pojo1("a", "b"), null, true);
@@ -256,8 +255,7 @@ public abstract class AbstractDockerTest {
 
   @Test
   void testDropMessageOnPredicateMissMatch() throws Exception {
-    String userConfig =
-        ("" + "{\"steps\": [" + "    {\"type\": \"drop\", \"when\": \"value.a=='a'\"}" + "]}");
+    String userConfig = "{\"steps\": [{\"type\": \"drop\", \"when\": \"value.a=='a'\"}]}";
     GenericRecord value =
         testTransformFunction(userConfig, Schema.AVRO(Pojo1.class), new Pojo1("c", "d"));
     assertEquals(value.getSchemaType(), SchemaType.AVRO);


### PR DESCRIPTION
This step will drop the current record from further processing. It is most useful when used with `when` predicates to selectively choose which messages to drop.

Step config example:

```
{
    "steps": [
        {
            "type": "drop-message",
            "when": "messageKey=='abc'"
        }
    ]
}
``` 

**Implementation note:**
There is a slight difference between the handling of null [Function.process](https://github.com/apache/pulsar/blame/master/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Function.java#L40) result between LS and OSS Pulsar - although both lead to an auto ack of the message without further processing [[LS](https://github.com/datastax/pulsar/blob/b980f73909c00997b5c5c97623f470aa65de1cdc/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java#L396), [OSS](https://github.com/apache/pulsar/blob/master/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java#L392)]. The drop step in this PR relies on the fact that `null` means ignore the message from further processing.