### PR TITLE
Implement compute-fields step

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import static org.apache.pulsar.common.schema.SchemaType.*;
+import static org.apache.pulsar.common.schema.SchemaType.STRING;
+
+import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
+import com.datastax.oss.pulsar.functions.transforms.predicate.jstl.JstlEvaluator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.pulsar.common.schema.SchemaType;
+
+/** Computes a field dynamically based on JSTL expressions and adds it to the key or the value . */
+@Builder
+public class ComputeFieldStep implements TransformStep {
+
+  @Builder.Default private final List<ComputeField> keyFields = new ArrayList<>();
+  @Builder.Default private final List<ComputeField> valueFields = new ArrayList<>();
+  private final Map<org.apache.avro.Schema, org.apache.avro.Schema> keySchemaCache =
+      new ConcurrentHashMap<>();
+  private final Map<org.apache.avro.Schema, org.apache.avro.Schema> valueSchemaCache =
+      new ConcurrentHashMap<>();
+
+  @Override
+  public void process(TransformContext transformContext) {
+    computeKeyFields(keyFields, transformContext);
+    computeValueFields(valueFields, transformContext);
+  }
+
+  public void computeValueFields(List<ComputeField> fields, TransformContext context) {
+    if (context.getValueSchema().getSchemaInfo().getType() == AVRO) {
+      GenericRecord avroRecord = (GenericRecord) context.getValueObject();
+      GenericRecord newRecord = computeFields(fields, avroRecord, valueSchemaCache, context);
+      if (avroRecord != newRecord) {
+        context.setValueModified(true);
+      }
+      context.setValueObject(newRecord);
+    }
+  }
+
+  public void computeKeyFields(List<ComputeField> fields, TransformContext context) {
+    if (context.getKeyObject() != null
+        && context.getValueSchema().getSchemaInfo().getType() == AVRO) {
+      GenericRecord avroRecord = (GenericRecord) context.getKeyObject();
+      GenericRecord newRecord = computeFields(fields, avroRecord, keySchemaCache, context);
+      if (avroRecord != newRecord) {
+        context.setKeyModified(true);
+      }
+      context.setKeyObject(newRecord);
+    }
+  }
+
+  private GenericRecord computeFields(
+      List<ComputeField> fields,
+      GenericRecord record,
+      Map<org.apache.avro.Schema, org.apache.avro.Schema> schemaCache,
+      TransformContext context) {
+    org.apache.avro.Schema avroSchema = record.getSchema();
+
+    List<Schema.Field> computedFields =
+        fields
+            .stream()
+            .map(f -> new org.apache.avro.Schema.Field(f.getName(), getSchema(f.getSchemaType())))
+            .collect(Collectors.toList());
+    List<Schema.Field> newFields =
+        avroSchema
+            .getFields()
+            .stream()
+            .map(
+                f ->
+                    new org.apache.avro.Schema.Field(
+                        f.name(), f.schema(), f.doc(), f.defaultVal(), f.order()))
+            .collect(Collectors.toList());
+    newFields.addAll(computedFields);
+    org.apache.avro.Schema newSchema =
+        schemaCache.computeIfAbsent(
+            avroSchema,
+            schema ->
+                org.apache.avro.Schema.createRecord(
+                    avroSchema.getName(),
+                    avroSchema.getDoc(),
+                    avroSchema.getNamespace(),
+                    avroSchema.isError(),
+                    newFields));
+
+    GenericRecord newRecord = new GenericData.Record(newSchema);
+    // Add original fields
+    for (org.apache.avro.Schema.Field field : avroSchema.getFields()) {
+      newRecord.put(field.name(), record.get(field.name()));
+    }
+    // Add computed fields
+    for (ComputeField field : fields) {
+      newRecord.put(
+          field.getName(),
+          new JstlEvaluator(field.getExpression(), getType(field.getSchemaType()))
+              .evaluate(context));
+    }
+    return newRecord;
+  }
+
+  private Class<?> getType(SchemaType schemaType) {
+    switch (schemaType) {
+      case STRING:
+        return String.class;
+      case INT8:
+      case INT16:
+      case INT32:
+        return Integer.class;
+      case INT64:
+        return Long.class;
+      default:
+        throw new UnsupportedOperationException("Unsupported schema type: " + schemaType);
+    }
+  }
+
+  Schema getSchema(SchemaType schemaType) {
+    switch (schemaType) {
+      case STRING:
+        return Schema.create(Schema.Type.STRING);
+      case INT8:
+      case INT16:
+      case INT32:
+      case INT64:
+        return Schema.create(Schema.Type.INT);
+      default:
+        throw new UnsupportedOperationException("Unsupported schema type: " + schemaType);
+    }
+  }
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model;
+
+import lombok.Data;
+import org.apache.pulsar.common.schema.SchemaType;
+
+@Data
+public class ComputeField {
+  private final String name;
+  private final String expression;
+  private final SchemaType schemaType;
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlEvaluator.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/predicate/jstl/JstlEvaluator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.predicate.jstl;
+
+import com.datastax.oss.pulsar.functions.transforms.TransformContext;
+import de.odysseus.el.ExpressionFactoryImpl;
+import de.odysseus.el.util.SimpleContext;
+import java.util.Map;
+import javax.el.ELContext;
+import javax.el.ExpressionFactory;
+import javax.el.ValueExpression;
+
+public class JstlEvaluator {
+
+  private static final ExpressionFactory FACTORY = new ExpressionFactoryImpl();
+  private final ValueExpression valueExpression;
+  private final ELContext expressionContext;
+
+  public JstlEvaluator(String expression, Class<?> type) {
+    this.expressionContext = new SimpleContext();
+    try {
+      this.valueExpression =
+          FACTORY.createValueExpression(
+              expressionContext, String.format("${%s}", expression), type);
+    } catch (RuntimeException ex) {
+      throw new IllegalArgumentException("invalid when: " + expression, ex);
+    }
+  }
+
+  public Object evaluate(TransformContext transformContext) {
+    // TODO: Add JstlAbstract class and reuse the binding code between the predicate and the
+    // evaluator.
+    JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+    FACTORY
+        .createValueExpression(expressionContext, "${key}", Object.class)
+        .setValue(expressionContext, adapter.getKey());
+    FACTORY
+        .createValueExpression(expressionContext, "${value}", Object.class)
+        .setValue(expressionContext, adapter.getValue());
+
+    // Register message headers as top level fields
+    FACTORY
+        .createValueExpression(expressionContext, "${messageKey}", String.class)
+        .setValue(expressionContext, adapter.getHeader().get("messageKey"));
+    FACTORY
+        .createValueExpression(expressionContext, "${topicName}", String.class)
+        .setValue(expressionContext, adapter.getHeader().get("topicName"));
+    FACTORY
+        .createValueExpression(expressionContext, "${destinationTopic}", String.class)
+        .setValue(expressionContext, adapter.getHeader().get("destinationTopic"));
+    FACTORY
+        .createValueExpression(expressionContext, "${eventTime}", Long.class)
+        .setValue(expressionContext, adapter.getHeader().get("eventTime"));
+    FACTORY
+        .createValueExpression(expressionContext, "${properties}", Map.class)
+        .setValue(expressionContext, adapter.getHeader().get("properties"));
+    return this.valueExpression.getValue(expressionContext);
+  }
+}


### PR DESCRIPTION
This patch adds support for `compute-fields` transformation step. It works as follows:
* Each `compute-fields` has an a list of `fields` to compute. Each `field` is a map of the following mandatory fields:
  * `name`[mandatory]: The name of the new field
  * `expression`[mandatory]: a JSTL based expression that computes the value of the fields. It could evaluate the fields based on operators only (like `1 + 1`) or it could reference fields from other parts of the message (key or value) 
  * `schema-type`: The pulsar schema type of the output fields (eg. STRING, INT32, etc.)
* The overall step has a `part` config that decides where to add fields (key, value). If null, it computes the field on both key & value (I'm thinking this should be mandatory field).

**Implementation note:** 
There are two types of schema related conversion that happen behind the sciences:
* From Pulsar Schema -> Native Schema (Avro only is supported today)
* From Pulsar Schema -> Java Type (required for explicit evaluation of the JSTL expression)