### PR TITLE
Add config model to leverage jackson mapper

### DIFF
--- a/pulsar-transformations/pom.xml
+++ b/pulsar-transformations/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>

--- a/pulsar-transformations/pom.xml
+++ b/pulsar-transformations/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
@@ -19,28 +19,23 @@ import static org.apache.pulsar.common.schema.SchemaType.AVRO;
 
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
 import lombok.Builder;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 
-/**
- * Computes a field dynamically based on JSTL expressions and adds it to the key or the value .
- */
+/** Computes a field dynamically based on JSTL expressions and adds it to the key or the value . */
 @Builder
 public class ComputeFieldStep implements TransformStep {
 
-  @Builder.Default
-  private final List<ComputeField> fields = new ArrayList<>();
+  @Builder.Default private final List<ComputeField> fields = new ArrayList<>();
   private final Map<org.apache.avro.Schema, org.apache.avro.Schema> keySchemaCache =
       new ConcurrentHashMap<>();
   private final Map<org.apache.avro.Schema, org.apache.avro.Schema> valueSchemaCache =

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/CastConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/CastConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+import lombok.Getter;
+
+@Getter
+public class CastConfig extends StepConfig {
+  @JsonProperty(value = "schema-type", required = true)
+  private String schemaType;
+
+  private Optional<String> part = Optional.empty();
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/CastConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/CastConfig.java
@@ -16,7 +16,6 @@
 package com.datastax.oss.pulsar.functions.transforms.model.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Optional;
 import lombok.Getter;
 
 @Getter
@@ -24,5 +23,6 @@ public class CastConfig extends StepConfig {
   @JsonProperty(value = "schema-type", required = true)
   private String schemaType;
 
-  private Optional<String> part = Optional.empty();
+  @JsonProperty(required = false)
+  private String part;
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/ComputeFieldsConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/ComputeFieldsConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ComputeFieldsConfig extends StepConfig {
+  @JsonProperty(required = true)
+  private List<ComputeField> fields;
+
+  @Getter
+  public static class ComputeField {
+    @JsonProperty(required = true)
+    private String name;
+
+    @JsonProperty(required = true)
+    private String expression;
+
+    @JsonProperty(required = true)
+    private ComputeFieldType type;
+
+    private boolean optional = true;
+  }
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/DropConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/DropConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class DropConfig extends StepConfig {
+  @JsonProperty(required = true)
+  private List<String> fields;
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/DropFieldsConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/DropFieldsConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Optional;
+import lombok.Getter;
+
+@Getter
+public class DropFieldsConfig extends StepConfig {
+  @JsonProperty(required = true)
+  private List<String> fields;
+
+  private Optional<String> part = Optional.empty();
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/DropFieldsConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/DropFieldsConfig.java
@@ -17,7 +17,6 @@ package com.datastax.oss.pulsar.functions.transforms.model.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import java.util.Optional;
 import lombok.Getter;
 
 @Getter
@@ -25,5 +24,6 @@ public class DropFieldsConfig extends StepConfig {
   @JsonProperty(required = true)
   private List<String> fields;
 
-  private Optional<String> part = Optional.empty();
+  @JsonProperty(required = false)
+  private String part;
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/FlattenConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/FlattenConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+import java.util.Optional;
+import lombok.Getter;
+
+@Getter
+public class FlattenConfig extends StepConfig {
+  private Optional<String> delimiter = Optional.empty();
+  private Optional<String> part = Optional.empty();
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/FlattenConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/FlattenConfig.java
@@ -15,11 +15,14 @@
  */
 package com.datastax.oss.pulsar.functions.transforms.model.config;
 
-import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
 public class FlattenConfig extends StepConfig {
-  private Optional<String> delimiter = Optional.empty();
-  private Optional<String> part = Optional.empty();
+  @JsonProperty(required = false)
+  private String delimiter;
+
+  @JsonProperty(required = false)
+  private String part;
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/MergeKeyValueConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/MergeKeyValueConfig.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+
+public class MergeKeyValueConfig extends StepConfig {}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/MergeKeyValueConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/MergeKeyValueConfig.java
@@ -15,5 +15,4 @@
  */
 package com.datastax.oss.pulsar.functions.transforms.model.config;
 
-
 public class MergeKeyValueConfig extends StepConfig {}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/StepConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/StepConfig.java
@@ -18,7 +18,6 @@ package com.datastax.oss.pulsar.functions.transforms.model.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.util.Optional;
 import lombok.Getter;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
@@ -38,5 +37,6 @@ public abstract class StepConfig {
   @JsonProperty(required = true)
   private String type;
 
-  private Optional<String> when = Optional.empty();
+  @JsonProperty(required = false)
+  private String when;
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/StepConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/StepConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.Optional;
+import lombok.Getter;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes(
+  value = {
+    @JsonSubTypes.Type(value = DropFieldsConfig.class, name = "drop-fields"),
+    @JsonSubTypes.Type(value = UnwrapKeyValueConfig.class, name = "unwrap-key-value"),
+    @JsonSubTypes.Type(value = MergeKeyValueConfig.class, name = "merge-key-value"),
+    @JsonSubTypes.Type(value = CastConfig.class, name = "cast"),
+    @JsonSubTypes.Type(value = DropConfig.class, name = "drop"),
+    @JsonSubTypes.Type(value = FlattenConfig.class, name = "flatten"),
+    @JsonSubTypes.Type(value = ComputeFieldsConfig.class, name = "compute-fields"),
+  }
+)
+@Getter
+public abstract class StepConfig {
+  @JsonProperty(required = true)
+  private String type;
+
+  private Optional<String> when = Optional.empty();
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/TransformStepConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/TransformStepConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class TransformStepConfig {
+  @JsonProperty(required = true)
+  private List<StepConfig> steps;
+}

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/UnwrapKeyValueConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/UnwrapKeyValueConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class UnwrapKeyValueConfig extends StepConfig {
+  @JsonProperty(value = "schema-type", required = true)
+  private String schemaType;
+
+  @JsonProperty("unwrap-key")
+  private boolean unwrapKey;
+}


### PR DESCRIPTION
This patch adds concrete model that represents step config. It will simplify few things like:
* Avoid parsing the configs manually from JsonNode
* Handling of default values of option fields. 
* Leverage the optional types for config null checks

Note:
* `jackson-datatype-jdk8` is added to support java.util.optional
* Because we have customer error validation, it looks like we are using jackson mapper twice. However the validation logic should be removed at some point when the `networknt` validation limitations are fixed.