### PR TITLE
Improve the usability of string functions

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
@@ -19,28 +19,23 @@ import static org.apache.pulsar.common.schema.SchemaType.AVRO;
 
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
 import lombok.Builder;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 
-/**
- * Computes a field dynamically based on JSTL expressions and adds it to the key or the value .
- */
+/** Computes a field dynamically based on JSTL expressions and adds it to the key or the value . */
 @Builder
 public class ComputeFieldStep implements TransformStep {
 
-  @Builder.Default
-  private final List<ComputeField> fields = new ArrayList<>();
+  @Builder.Default private final List<ComputeField> fields = new ArrayList<>();
   private final Map<org.apache.avro.Schema, org.apache.avro.Schema> keySchemaCache =
       new ConcurrentHashMap<>();
   private final Map<org.apache.avro.Schema, org.apache.avro.Schema> valueSchemaCache =

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlEvaluator.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlEvaluator.java
@@ -47,11 +47,15 @@ public class JstlEvaluator<T> {
   @SneakyThrows
   private void registerFunctions(SimpleContext expressionContext) {
     this.expressionContext.setFunction(
-        "fn", "uppercase", JstlFunctions.class.getMethod("uppercase", String.class));
+        "fn", "uppercase", JstlFunctions.class.getMethod("uppercase", Object.class));
     this.expressionContext.setFunction(
-        "fn", "lowercase", JstlFunctions.class.getMethod("lowercase", String.class));
+        "fn", "lowercase", JstlFunctions.class.getMethod("lowercase", Object.class));
     this.expressionContext.setFunction(
-        "fn", "contains", JstlFunctions.class.getMethod("contains", String.class, String.class));
+        "fn", "contains", JstlFunctions.class.getMethod("contains", Object.class, Object.class));
+    this.expressionContext.setFunction(
+        "fn", "trim", JstlFunctions.class.getMethod("trim", Object.class));
+    this.expressionContext.setFunction(
+        "fn", "concat", JstlFunctions.class.getMethod("concat", Object.class, Object.class));
     this.expressionContext.setFunction(
         "fn", "coalesce", JstlFunctions.class.getMethod("coalesce", Object.class, Object.class));
   }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
@@ -15,19 +15,31 @@
  */
 package com.datastax.oss.pulsar.functions.transforms.jstl;
 
+
 /** Provides convenience methods to use in jstl expression. All functions should be static. */
 public class JstlFunctions {
 
-  public static String uppercase(String input) {
-    return input.toUpperCase();
+  public static String uppercase(Object input) {
+    return input == null ? null : input.toString().toUpperCase();
   }
 
-  public static String lowercase(String input) {
-    return input.toLowerCase();
+  public static String lowercase(Object input) {
+    return input == null ? null : input.toString().toLowerCase();
   }
 
-  public static boolean contains(String input, String value) {
-    return input.contains(value);
+  public static boolean contains(Object input, Object value) {
+    if (input == null || value == null) {
+      return false;
+    }
+    return input.toString().contains(value.toString());
+  }
+
+  public static String trim(Object input) {
+    return input == null ? null : input.toString().trim();
+  }
+
+  public static String concat(Object first, Object second) {
+    return (first == null ? "" : first.toString()) + (second == null ? "" : second.toString());
   }
 
   public static Object coalesce(Object value, Object valueIfNull) {

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstEvaluatorTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstEvaluatorTest.java
@@ -83,13 +83,22 @@ public class JstEvaluatorTest {
     return new Object[][] {
       {"fn:uppercase('test')", primitiveStringContext, "TEST"},
       {"fn:uppercase(value) == 'TEST-MESSAGE'", primitiveStringContext, true},
+      {"fn:uppercase(null)", primitiveStringContext, null},
       {"fn:lowercase('TEST')", primitiveStringContext, "test"},
       {"fn:lowercase(value) == 'test-message'", primitiveStringContext, true},
       {"fn:lowercase(fn:uppercase(value)) == 'test-message'", primitiveStringContext, true},
       {"fn:lowercase(fn:coalesce(null, 'another-value'))", primitiveStringContext, "another-value"},
       {"fn:lowercase(fn:coalesce('value', 'another-value'))", primitiveStringContext, "value"},
+      {"fn:lowercase(null)", primitiveStringContext, null},
       {"fn:contains(value, 'test')", primitiveStringContext, true},
       {"fn:contains(value, 'random')", primitiveStringContext, false},
+      {"fn:contains(null, 'random')", primitiveStringContext, false},
+      {"fn:contains(value, null)", primitiveStringContext, false},
+      {"fn:trim('    trimmed      ')", primitiveStringContext, "trimmed"},
+      {"fn:trim(null)", primitiveStringContext, null},
+      {"fn:concat(value, '-suffix')", primitiveStringContext, "test-message-suffix"},
+      {"fn:concat(value, null)", primitiveStringContext, "test-message"},
+      {"fn:concat(null, '-suffix')", primitiveStringContext, "-suffix"},
     };
   }
 }

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.jstl;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import org.testng.annotations.Test;
+
+public class JstlFunctionsTest {
+
+  @Test
+  void testUpperCase() {
+    assertEquals("UPPERCASE", JstlFunctions.uppercase("uppercase"));
+  }
+
+  @Test
+  void testUpperCaseInteger() {}
+
+  @Test
+  void testUpperCaseNull() {
+    assertEquals(null, JstlFunctions.uppercase(null));
+  }
+
+  @Test
+  void testLowerCase() {
+    assertEquals("lowercase", JstlFunctions.lowercase("LOWERCASE"));
+  }
+
+  @Test
+  void testLowerCaseInteger() {
+    assertEquals("10", JstlFunctions.uppercase(10));
+  }
+
+  @Test
+  void testLowerCaseNull() {
+    assertEquals(null, JstlFunctions.uppercase(null));
+  }
+
+  @Test
+  void testContains() {
+    assertTrue(JstlFunctions.contains("full text", "l t"));
+    assertTrue(JstlFunctions.contains("full text", "full"));
+    assertTrue(JstlFunctions.contains("full text", "text"));
+
+    assertFalse(JstlFunctions.contains("full text", "lt"));
+    assertFalse(JstlFunctions.contains("full text", "fll"));
+    assertFalse(JstlFunctions.contains("full text", "txt"));
+  }
+
+  @Test
+  void testContainsInteger() {
+    assertTrue(JstlFunctions.contains(123, "2"));
+    assertTrue(JstlFunctions.contains("123", 3));
+    assertTrue(JstlFunctions.contains(123, 3));
+    assertTrue(JstlFunctions.contains("123", "3"));
+
+    assertFalse(JstlFunctions.contains(123, "4"));
+    assertFalse(JstlFunctions.contains("123", 4));
+    assertFalse(JstlFunctions.contains(123, 4));
+    assertFalse(JstlFunctions.contains("123", "4"));
+  }
+
+  @Test
+  void testContainsNull() {
+    assertFalse(JstlFunctions.contains("null", null));
+    assertFalse(JstlFunctions.contains(null, "null"));
+    assertFalse(JstlFunctions.contains(null, null));
+  }
+
+  @Test
+  void testConcat() {
+    assertEquals("full text", JstlFunctions.concat("full ", "text"));
+  }
+
+  void testConcatInteger() {
+    assertEquals("12", JstlFunctions.concat(1, 2));
+    assertEquals("12", JstlFunctions.concat("1", 2));
+    assertEquals("12", JstlFunctions.concat(1, "2"));
+  }
+
+  void testConcatNull() {
+    assertEquals("text", JstlFunctions.concat(null, "text"));
+    assertEquals("full ", JstlFunctions.concat("full ", null));
+    assertEquals("", JstlFunctions.concat(null, null));
+  }
+}


### PR DESCRIPTION
Fixes #21 

The patch gracefully handles nulls, and adds two string methods: `contact` and `trim`