### PR TITLE
Support date/time compute fields

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
@@ -19,9 +19,9 @@ import static org.apache.pulsar.common.schema.SchemaType.AVRO;
 
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -202,9 +202,9 @@ public class ComputeFieldStep implements TransformStep {
         LocalTime localTime = (LocalTime) value;
         return (int) (localTime.toNanoOfDay() / 1000000);
       case "timestamp-millis":
-        validateLogicalType(value, schema.getLogicalType(), Instant.class);
-        Instant instant = (Instant) value;
-        return instant.toEpochMilli();
+        validateLogicalType(value, schema.getLogicalType(), OffsetDateTime.class);
+        OffsetDateTime offsetDateTime = (OffsetDateTime) value;
+        return offsetDateTime.toInstant().toEpochMilli();
     }
 
     throw new IllegalArgumentException(

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
@@ -19,10 +19,9 @@ import static org.apache.pulsar.common.schema.SchemaType.AVRO;
 
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -203,9 +202,9 @@ public class ComputeFieldStep implements TransformStep {
         LocalTime localTime = (LocalTime) value;
         return (int) (localTime.toNanoOfDay() / 1000000);
       case "timestamp-millis":
-        validateLogicalType(value, schema.getLogicalType(), LocalDateTime.class);
-        LocalDateTime localDateTime = (LocalDateTime) value;
-        return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        validateLogicalType(value, schema.getLogicalType(), Instant.class);
+        Instant instant = (Instant) value;
+        return instant.toEpochMilli();
     }
 
     throw new IllegalArgumentException(

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
@@ -19,6 +19,10 @@ import static org.apache.pulsar.common.schema.SchemaType.AVRO;
 
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +30,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import lombok.Builder;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
@@ -167,10 +173,64 @@ public class ComputeFieldStep implements TransformStep {
     }
     // Add computed fields
     for (ComputeField field : fields) {
-      newRecordBuilder.set(field.getName(), field.getEvaluator().evaluate(context));
-      ;
+      newRecordBuilder.set(
+          field.getName(),
+          getAvroValue(
+              newSchema.getField(field.getName()).schema(),
+              field.getEvaluator().evaluate(context)));
     }
     return newRecordBuilder.build();
+  }
+
+  private Object getAvroValue(Schema schema, Object value) {
+    if (value == null) {
+      return null;
+    }
+
+    LogicalType logicalType = getLogicalType(schema);
+    if (logicalType == null) {
+      return value;
+    }
+
+    // Avro logical type conversion: https://avro.apache.org/docs/1.8.2/spec.html#Logical+Types
+    switch (logicalType.getName()) {
+      case "date":
+        validateLogicalType(value, schema.getLogicalType(), LocalDate.class);
+        LocalDate localDate = (LocalDate) value;
+        return (int) localDate.toEpochDay();
+      case "time-millis":
+        validateLogicalType(value, schema.getLogicalType(), LocalTime.class);
+        LocalTime localTime = (LocalTime) value;
+        return (int) (localTime.toNanoOfDay() / 1000000);
+      case "timestamp-millis":
+        validateLogicalType(value, schema.getLogicalType(), LocalDateTime.class);
+        LocalDateTime localDateTime = (LocalDateTime) value;
+        return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    throw new IllegalArgumentException(
+        String.format("Invalid logical type %s for value %s", schema.getLogicalType(), value));
+  }
+
+  private LogicalType getLogicalType(Schema schema) {
+    if (!schema.isUnion()) {
+      return schema.getLogicalType();
+    }
+
+    return schema
+        .getTypes()
+        .stream()
+        .filter(subSchema -> subSchema.getLogicalType() != null)
+        .map(Schema::getLogicalType)
+        .findAny()
+        .orElse(null);
+  }
+
+  void validateLogicalType(Object value, LogicalType logicalType, Class expectedClass) {
+    if (!(value.getClass().equals(expectedClass))) {
+      throw new IllegalArgumentException(
+          String.format("Invalid value %s for logical type %s", value, logicalType));
+    }
   }
 
   private Schema.Field createAvroField(ComputeField field) {
@@ -190,9 +250,12 @@ public class ComputeFieldStep implements TransformStep {
         schemaType = Schema.Type.STRING;
         break;
       case INT32:
+      case DATE:
+      case TIME:
         schemaType = Schema.Type.INT;
         break;
       case INT64:
+      case DATETIME:
         schemaType = Schema.Type.LONG;
         break;
       case FLOAT:
@@ -208,6 +271,21 @@ public class ComputeFieldStep implements TransformStep {
         throw new UnsupportedOperationException("Unsupported compute field type: " + type);
     }
 
-    return fieldTypeToAvroSchemaCache.computeIfAbsent(type, (ignored) -> Schema.create(schemaType));
+    return fieldTypeToAvroSchemaCache.computeIfAbsent(
+        type,
+        key -> {
+          // Handle logical types: https://avro.apache.org/docs/1.10.2/spec.html#Logical+Types
+          Schema schema = Schema.create(schemaType);
+          switch (key) {
+            case DATE:
+              return LogicalTypes.date().addToSchema(schema);
+            case TIME:
+              return LogicalTypes.timeMillis().addToSchema(schema);
+            case DATETIME:
+              return LogicalTypes.timestampMillis().addToSchema(schema);
+            default:
+              return schema;
+          }
+        });
   }
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
@@ -25,6 +25,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -219,8 +220,8 @@ public class ComputeFieldStep implements TransformStep {
     return schema
         .getTypes()
         .stream()
-        .filter(subSchema -> subSchema.getLogicalType() != null)
         .map(Schema::getLogicalType)
+        .filter(Objects::nonNull)
         .findAny()
         .orElse(null);
   }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
@@ -17,17 +17,29 @@ package com.datastax.oss.pulsar.functions.transforms.jstl;
 
 import de.odysseus.el.misc.TypeConverter;
 import de.odysseus.el.misc.TypeConverterImpl;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import javax.el.ELException;
 
 /**
- * Overrides the default TypeConverter coerce for null values. This fits better with Avro's nullable
- * schemas.
+ * Overrides the default TypeConverter coerce to support null values & non-EL coercions (e.g.
+ * date/time types) schemas.
  */
-public class NullableTypeConverter implements TypeConverter {
+public class CustomTypeConverter implements TypeConverter {
   private static TypeConverterImpl typeConverter = new TypeConverterImpl();
 
   @Override
   public <T> T convert(Object o, Class<T> aClass) throws ELException {
-    return o == null ? null : typeConverter.convert(o, aClass);
+    if (o == null) {
+      return null;
+    } else if ("java.time.LocalDate".equals(aClass.getName())) {
+      return (T) LocalDate.parse(o.toString());
+    } else if ("java.time.LocalTime".equals(aClass.getName())) {
+      return (T) LocalTime.parse(o.toString());
+    } else if ("java.time.LocalDateTime".equals(aClass.getName())) {
+      return (T) LocalDateTime.parse(o.toString());
+    }
+    return typeConverter.convert(o, aClass);
   }
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
@@ -17,9 +17,9 @@ package com.datastax.oss.pulsar.functions.transforms.jstl;
 
 import de.odysseus.el.misc.TypeConverter;
 import de.odysseus.el.misc.TypeConverterImpl;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import javax.el.ELException;
 
 /**
@@ -37,8 +37,8 @@ public class CustomTypeConverter implements TypeConverter {
       return (T) LocalDate.parse(o.toString());
     } else if (aClass == LocalTime.class) {
       return (T) LocalTime.parse(o.toString());
-    } else if (aClass == Instant.class) {
-      return (T) Instant.parse(o.toString());
+    } else if (aClass == OffsetDateTime.class) {
+      return (T) OffsetDateTime.parse(o.toString());
     }
     return typeConverter.convert(o, aClass);
   }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
@@ -33,11 +33,11 @@ public class CustomTypeConverter implements TypeConverter {
   public <T> T convert(Object o, Class<T> aClass) throws ELException {
     if (o == null) {
       return null;
-    } else if ("java.time.LocalDate".equals(aClass.getName())) {
+    } else if (aClass == LocalDate.class) {
       return (T) LocalDate.parse(o.toString());
-    } else if ("java.time.LocalTime".equals(aClass.getName())) {
+    } else if (aClass == LocalTime.class) {
       return (T) LocalTime.parse(o.toString());
-    } else if ("java.time.LocalDateTime".equals(aClass.getName())) {
+    } else if (aClass == LocalDateTime.class) {
       return (T) LocalDateTime.parse(o.toString());
     }
     return typeConverter.convert(o, aClass);

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
@@ -17,8 +17,8 @@ package com.datastax.oss.pulsar.functions.transforms.jstl;
 
 import de.odysseus.el.misc.TypeConverter;
 import de.odysseus.el.misc.TypeConverterImpl;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import javax.el.ELException;
 
@@ -37,8 +37,8 @@ public class CustomTypeConverter implements TypeConverter {
       return (T) LocalDate.parse(o.toString());
     } else if (aClass == LocalTime.class) {
       return (T) LocalTime.parse(o.toString());
-    } else if (aClass == LocalDateTime.class) {
-      return (T) LocalDateTime.parse(o.toString());
+    } else if (aClass == Instant.class) {
+      return (T) Instant.parse(o.toString());
     }
     return typeConverter.convert(o, aClass);
   }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlEvaluator.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlEvaluator.java
@@ -31,7 +31,7 @@ public class JstlEvaluator<T> {
   }
 
   private static final ExpressionFactory FACTORY =
-      new ExpressionFactoryImpl(System.getProperties(), new NullableTypeConverter());
+      new ExpressionFactoryImpl(System.getProperties(), new CustomTypeConverter());
   private final ValueExpression valueExpression;
   private final SimpleContext expressionContext;
 
@@ -58,6 +58,11 @@ public class JstlEvaluator<T> {
         "fn", "concat", JstlFunctions.class.getMethod("concat", Object.class, Object.class));
     this.expressionContext.setFunction(
         "fn", "coalesce", JstlFunctions.class.getMethod("coalesce", Object.class, Object.class));
+    this.expressionContext.setFunction("fn", "now", JstlFunctions.class.getMethod("now"));
+    this.expressionContext.setFunction(
+        "fn",
+        "dateadd",
+        JstlFunctions.class.getMethod("dateadd", Object.class, long.class, String.class));
   }
 
   public T evaluate(TransformContext transformContext) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.pulsar.functions.transforms.jstl;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -22,9 +23,11 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.Setter;
 
 /** Provides convenience methods to use in jstl expression. All functions should be static. */
 public class JstlFunctions {
+  @Setter private static Clock clock = Clock.systemUTC();
 
   public static String uppercase(Object input) {
     return input == null ? null : input.toString().toUpperCase();
@@ -54,7 +57,7 @@ public class JstlFunctions {
   }
 
   public static long now() {
-    return Instant.now().toEpochMilli();
+    return clock.millis();
   }
 
   private static final ZoneId UTC = ZoneId.of("UTC");

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
@@ -87,8 +87,8 @@ public class JstlFunctions {
   }
 
   private static long dateadd(String isoDateTime, long delta, String unit) {
-    LocalDateTime localDateTime = LocalDateTime.parse(isoDateTime);
-    return dateadd(localDateTime, delta, unit);
+    Instant instant = Instant.parse(isoDateTime);
+    return dateadd(LocalDateTime.ofInstant(instant, UTC), delta, unit);
   }
 
   private static long dateadd(long epochMillis, long delta, String unit) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
@@ -15,6 +15,14 @@
  */
 package com.datastax.oss.pulsar.functions.transforms.jstl;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
 /** Provides convenience methods to use in jstl expression. All functions should be static. */
 public class JstlFunctions {
 
@@ -43,5 +51,56 @@ public class JstlFunctions {
 
   public static Object coalesce(Object value, Object valueIfNull) {
     return value == null ? valueIfNull : value;
+  }
+
+  public static long now() {
+    return Instant.now().toEpochMilli();
+  }
+
+  private static final ZoneId UTC = ZoneId.of("UTC");
+  private static final Map<String, ChronoUnit> dateAddUnits = new HashMap<>();
+
+  static {
+    dateAddUnits.put("years", ChronoUnit.YEARS); // Instant.plus does not support years
+    dateAddUnits.put("months", ChronoUnit.MONTHS); // Instant.plus does not support months
+    dateAddUnits.put("days", ChronoUnit.DAYS);
+    dateAddUnits.put("hours", ChronoUnit.HOURS);
+    dateAddUnits.put("minutes", ChronoUnit.MINUTES);
+    dateAddUnits.put("seconds", ChronoUnit.SECONDS);
+    dateAddUnits.put("millis", ChronoUnit.MILLIS);
+  }
+
+  public static long dateadd(Object input, long delta, String unit) {
+    if (input instanceof String) {
+      return dateadd((String) input, delta, unit);
+    } else if (input instanceof Long) {
+      return dateadd((long) input, delta, unit);
+    }
+
+    throw new IllegalArgumentException(
+        "Invalid input type: "
+            + input.getClass().getSimpleName()
+            + ". Should either be an ISO datetime string like '2007-12-01T12:30:00' or epoch millis");
+  }
+
+  private static long dateadd(String isoDateTime, long delta, String unit) {
+    LocalDateTime localDateTime = LocalDateTime.parse(isoDateTime);
+    return dateadd(localDateTime, delta, unit);
+  }
+
+  private static long dateadd(long epochMillis, long delta, String unit) {
+    Instant instant = Instant.ofEpochMilli(epochMillis);
+    LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, UTC);
+    return dateadd(localDateTime, delta, unit);
+  }
+
+  private static long dateadd(LocalDateTime localDateTime, long delta, String unit) {
+    ChronoUnit chronoUnit = dateAddUnits.get(unit);
+    if (chronoUnit == null) {
+      throw new IllegalArgumentException(
+          "Invalid unit: " + unit + ". Should be one of " + dateAddUnits.keySet());
+    }
+
+    return localDateTime.plus(delta, chronoUnit).toInstant(ZoneOffset.UTC).toEpochMilli();
   }
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctions.java
@@ -20,8 +20,6 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.Setter;
 
 /** Provides convenience methods to use in jstl expression. All functions should be static. */
@@ -59,18 +57,6 @@ public class JstlFunctions {
     return clock.millis();
   }
 
-  private static final Map<String, ChronoUnit> dateAddUnits = new HashMap<>();
-
-  static {
-    dateAddUnits.put("years", ChronoUnit.YEARS);
-    dateAddUnits.put("months", ChronoUnit.MONTHS);
-    dateAddUnits.put("days", ChronoUnit.DAYS);
-    dateAddUnits.put("hours", ChronoUnit.HOURS);
-    dateAddUnits.put("minutes", ChronoUnit.MINUTES);
-    dateAddUnits.put("seconds", ChronoUnit.SECONDS);
-    dateAddUnits.put("millis", ChronoUnit.MILLIS);
-  }
-
   public static long dateadd(Object input, long delta, String unit) {
     if (input instanceof String) {
       return dateadd((String) input, delta, unit);
@@ -96,10 +82,34 @@ public class JstlFunctions {
   }
 
   private static long dateadd(OffsetDateTime offsetDateTime, long delta, String unit) {
-    ChronoUnit chronoUnit = dateAddUnits.get(unit);
-    if (chronoUnit == null) {
-      throw new IllegalArgumentException(
-          "Invalid unit: " + unit + ". Should be one of " + dateAddUnits.keySet());
+    final ChronoUnit chronoUnit;
+    switch (unit) {
+      case "years":
+        chronoUnit = ChronoUnit.YEARS;
+        break;
+      case "months":
+        chronoUnit = ChronoUnit.MONTHS;
+        break;
+      case "days":
+        chronoUnit = ChronoUnit.DAYS;
+        break;
+      case "hours":
+        chronoUnit = ChronoUnit.HOURS;
+        break;
+      case "minutes":
+        chronoUnit = ChronoUnit.MINUTES;
+        break;
+      case "seconds":
+        chronoUnit = ChronoUnit.SECONDS;
+        break;
+      case "millis":
+        chronoUnit = ChronoUnit.MILLIS;
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "Invalid unit: "
+                + unit
+                + ". Should be one of [years, months, days, hours, minutes, seconds, millis]");
     }
 
     return offsetDateTime.plus(delta, chronoUnit).toInstant().toEpochMilli();

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
@@ -16,6 +16,9 @@
 package com.datastax.oss.pulsar.functions.transforms.model;
 
 import com.datastax.oss.pulsar.functions.transforms.jstl.JstlEvaluator;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Set;
 import javax.el.ELException;
 import lombok.AccessLevel;
@@ -117,6 +120,12 @@ public class ComputeField {
           return double.class;
         case BOOLEAN:
           return boolean.class;
+        case DATE:
+          return LocalDate.class;
+        case TIME:
+          return LocalTime.class;
+        case DATETIME:
+          return LocalDateTime.class;
         default:
           throw new UnsupportedOperationException("Unsupported compute field type: " + type);
       }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
@@ -16,8 +16,8 @@
 package com.datastax.oss.pulsar.functions.transforms.model;
 
 import com.datastax.oss.pulsar.functions.transforms.jstl.JstlEvaluator;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Set;
 import javax.el.ELException;
@@ -125,7 +125,7 @@ public class ComputeField {
         case TIME:
           return LocalTime.class;
         case DATETIME:
-          return LocalDateTime.class;
+          return Instant.class;
         default:
           throw new UnsupportedOperationException("Unsupported compute field type: " + type);
       }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
@@ -16,9 +16,9 @@
 package com.datastax.oss.pulsar.functions.transforms.model;
 
 import com.datastax.oss.pulsar.functions.transforms.jstl.JstlEvaluator;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Set;
 import javax.el.ELException;
 import lombok.AccessLevel;
@@ -125,7 +125,7 @@ public class ComputeField {
         case TIME:
           return LocalTime.class;
         case DATETIME:
-          return Instant.class;
+          return OffsetDateTime.class;
         default:
           throw new UnsupportedOperationException("Unsupported compute field type: " + type);
       }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeFieldType.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeFieldType.java
@@ -21,5 +21,8 @@ public enum ComputeFieldType {
   INT64,
   FLOAT,
   DOUBLE,
-  BOOLEAN
+  BOOLEAN,
+  DATE,
+  TIME,
+  DATETIME
 }

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStepTest.java
@@ -28,7 +28,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -141,7 +141,8 @@ public class ComputeFieldStepTest {
     assertTrue(read.hasField("newDateTimeField"));
     assertEquals(read.getSchema().getField("newDateTimeField").schema(), TIMESTAMP_SCHEMA);
     assertEquals(
-        read.get("newDateTimeField"), Instant.parse("2007-12-03T10:15:30.00Z").toEpochMilli());
+        read.get("newDateTimeField"),
+        OffsetDateTime.parse("2007-12-03T10:15:30.00Z").toInstant().toEpochMilli());
 
     assertEquals(read.getSchema().getField("age").schema(), STRING_SCHEMA);
     assertEquals(read.get("age"), new Utf8("43"));
@@ -527,7 +528,7 @@ public class ComputeFieldStepTest {
     fields.add(
         ComputeField.builder()
             .scopedName(scope + "." + "newDateTimeField")
-            .expression(nullify ? "null" : "'2007-12-03T10:15:30Z'")
+            .expression(nullify ? "null" : "'2007-12-03T10:15:30+00:00'")
             .optional(optional)
             .type(ComputeFieldType.DATETIME)
             .build());

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStepTest.java
@@ -28,11 +28,13 @@ import static org.testng.Assert.assertTrue;
 
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.util.Utf8;
 import org.apache.pulsar.client.api.Schema;
@@ -52,6 +54,22 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ComputeFieldStepTest {
+
+  private static final org.apache.avro.Schema STRING_SCHEMA = org.apache.avro.Schema.create(STRING);
+  private static final org.apache.avro.Schema INT_SCHEMA = org.apache.avro.Schema.create(INT);
+  private static final org.apache.avro.Schema LONG_SCHEMA = org.apache.avro.Schema.create(LONG);
+  private static final org.apache.avro.Schema FLOAT_SCHEMA = org.apache.avro.Schema.create(FLOAT);
+  private static final org.apache.avro.Schema DOUBLE_SCHEMA = org.apache.avro.Schema.create(DOUBLE);
+  private static final org.apache.avro.Schema BOOLEAN_SCHEMA =
+      org.apache.avro.Schema.create(BOOLEAN);
+
+  private static final org.apache.avro.Schema DATE_SCHEMA =
+      LogicalTypes.date().addToSchema(org.apache.avro.Schema.create(INT));
+
+  private static final org.apache.avro.Schema TIME_SCHEMA =
+      LogicalTypes.timeMillis().addToSchema(org.apache.avro.Schema.create(INT));
+  private static final org.apache.avro.Schema TIMESTAMP_SCHEMA =
+      LogicalTypes.timestampMillis().addToSchema(org.apache.avro.Schema.create(LONG));
 
   @Test
   void testAvro() throws Exception {
@@ -89,30 +107,43 @@ public class ComputeFieldStepTest {
     assertEquals(read.get("firstName"), new Utf8("Jane"));
 
     assertTrue(read.hasField("newStringField"));
-    assertEquals(read.getSchema().getField("newStringField").schema().getType(), STRING);
+    assertEquals(read.getSchema().getField("newStringField").schema(), STRING_SCHEMA);
     assertEquals(read.get("newStringField"), new Utf8("Hotaru"));
 
     assertTrue(read.hasField("newInt32Field"));
-    assertEquals(read.getSchema().getField("newInt32Field").schema().getType(), INT);
+    assertEquals(read.getSchema().getField("newInt32Field").schema(), INT_SCHEMA);
     assertEquals(read.get("newInt32Field"), 2147483647);
 
     assertTrue(read.hasField("newInt64Field"));
-    assertEquals(read.getSchema().getField("newInt64Field").schema().getType(), LONG);
+    assertEquals(read.getSchema().getField("newInt64Field").schema(), LONG_SCHEMA);
     assertEquals(read.get("newInt64Field"), 9223372036854775807L);
 
     assertTrue(read.hasField("newFloatField"));
-    assertEquals(read.getSchema().getField("newFloatField").schema().getType(), FLOAT);
+    assertEquals(read.getSchema().getField("newFloatField").schema(), FLOAT_SCHEMA);
     assertEquals(read.get("newFloatField"), 340282346638528859999999999999999999999.999999F);
 
     assertTrue(read.hasField("newDoubleField"));
-    assertEquals(read.getSchema().getField("newDoubleField").schema().getType(), DOUBLE);
+    assertEquals(read.getSchema().getField("newDoubleField").schema(), DOUBLE_SCHEMA);
     assertEquals(read.get("newDoubleField"), 1.79769313486231570e+308D);
 
     assertTrue(read.hasField("newBooleanField"));
-    assertEquals(read.getSchema().getField("newBooleanField").schema().getType(), BOOLEAN);
+    assertEquals(read.getSchema().getField("newBooleanField").schema(), BOOLEAN_SCHEMA);
     assertTrue((Boolean) read.get("newBooleanField"));
 
-    assertEquals(read.getSchema().getField("age").schema().getType(), STRING);
+    assertTrue(read.hasField("newDateField"));
+    assertEquals(read.getSchema().getField("newDateField").schema(), DATE_SCHEMA);
+    assertEquals(read.get("newDateField"), 13850); // 13850 days since 1970-01-01
+
+    assertTrue(read.hasField("newTimeField"));
+    assertEquals(read.getSchema().getField("newTimeField").schema(), TIME_SCHEMA);
+    assertEquals(read.get("newTimeField"), 36930000); // 36930000 ms since 00:00:00
+
+    assertTrue(read.hasField("newDateTimeField"));
+    assertEquals(read.getSchema().getField("newDateTimeField").schema(), TIMESTAMP_SCHEMA);
+    assertEquals(
+        read.get("newDateTimeField"), Instant.parse("2007-12-03T10:15:30.00Z").toEpochMilli());
+
+    assertEquals(read.getSchema().getField("age").schema(), STRING_SCHEMA);
     assertEquals(read.get("age"), new Utf8("43"));
   }
 
@@ -478,6 +509,27 @@ public class ComputeFieldStepTest {
             .expression(nullify ? "null" : "1 == 1")
             .optional(optional)
             .type(ComputeFieldType.BOOLEAN)
+            .build());
+    fields.add(
+        ComputeField.builder()
+            .scopedName(scope + "." + "newDateField")
+            .expression(nullify ? "null" : "'2007-12-03'")
+            .optional(optional)
+            .type(ComputeFieldType.DATE)
+            .build());
+    fields.add(
+        ComputeField.builder()
+            .scopedName(scope + "." + "newTimeField")
+            .expression(nullify ? "null" : "'10:15:30'")
+            .optional(optional)
+            .type(ComputeFieldType.TIME)
+            .build());
+    fields.add(
+        ComputeField.builder()
+            .scopedName(scope + "." + "newDateTimeField")
+            .expression(nullify ? "null" : "'2007-12-03T10:15:30'")
+            .optional(optional)
+            .type(ComputeFieldType.DATETIME)
             .build());
 
     return fields;

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStepTest.java
@@ -527,7 +527,7 @@ public class ComputeFieldStepTest {
     fields.add(
         ComputeField.builder()
             .scopedName(scope + "." + "newDateTimeField")
-            .expression(nullify ? "null" : "'2007-12-03T10:15:30'")
+            .expression(nullify ? "null" : "'2007-12-03T10:15:30Z'")
             .optional(optional)
             .type(ComputeFieldType.DATETIME)
             .build());

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
@@ -20,8 +20,8 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import org.testng.annotations.Test;
 
 public class CustomTypeConverterTest {
@@ -37,7 +37,7 @@ public class CustomTypeConverterTest {
     assertNull(converter.convert(null, boolean.class));
     assertNull(converter.convert(null, LocalDate.class));
     assertNull(converter.convert(null, LocalTime.class));
-    assertNull(converter.convert(null, LocalDateTime.class));
+    assertNull(converter.convert(null, OffsetDateTime.class));
   }
 
   @Test
@@ -54,7 +54,7 @@ public class CustomTypeConverterTest {
     LocalTime expectedTime = LocalTime.of(10, 11, 12);
     assertEquals(expectedTime, converter.convert("10:11:12", LocalTime.class));
     assertEquals(
-        LocalDateTime.of(expectedDate, expectedTime),
-        converter.convert(LocalDateTime.parse("2022-12-02T10:11:12"), LocalDateTime.class));
+        OffsetDateTime.parse("2022-12-02T10:11:12Z"),
+        converter.convert("2022-12-02T10:11:12Z", OffsetDateTime.class));
   }
 }

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
@@ -19,29 +19,42 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import org.testng.annotations.Test;
 
-public class NullableTypeConverterTest {
+public class CustomTypeConverterTest {
 
   @Test
   void testNullConversion() {
-    NullableTypeConverter converter = new NullableTypeConverter();
+    CustomTypeConverter converter = new CustomTypeConverter();
     assertNull(converter.convert(null, String.class));
     assertNull(converter.convert(null, int.class));
     assertNull(converter.convert(null, long.class));
     assertNull(converter.convert(null, float.class));
     assertNull(converter.convert(null, double.class));
     assertNull(converter.convert(null, boolean.class));
+    assertNull(converter.convert(null, LocalDate.class));
+    assertNull(converter.convert(null, LocalTime.class));
+    assertNull(converter.convert(null, LocalDateTime.class));
   }
 
   @Test
   void testNonNullConversion() {
-    NullableTypeConverter converter = new NullableTypeConverter();
+    CustomTypeConverter converter = new CustomTypeConverter();
     assertEquals(converter.convert("test", String.class), "test");
     assertEquals((int) converter.convert(1, int.class), 1);
     assertEquals((long) converter.convert(1L, long.class), 1L);
     assertEquals(converter.convert(1.3F, float.class), 1.3F);
     assertEquals(converter.convert(1.4D, double.class), 1.4D);
     assertTrue(converter.convert(true, boolean.class));
+    LocalDate expectedDate = LocalDate.of(2022, 12, 2);
+    assertEquals(expectedDate, converter.convert("2022-12-02", LocalDate.class));
+    LocalTime expectedTime = LocalTime.of(10, 11, 12);
+    assertEquals(expectedTime, converter.convert("10:11:12", LocalTime.class));
+    assertEquals(
+        LocalDateTime.of(expectedDate, expectedTime),
+        converter.convert(LocalDateTime.parse("2022-12-02T10:11:12"), LocalDateTime.class));
   }
 }

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstEvaluatorTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstEvaluatorTest.java
@@ -16,12 +16,13 @@
 package com.datastax.oss.pulsar.functions.transforms.jstl;
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 
 import com.datastax.oss.pulsar.functions.transforms.TransformContext;
 import com.datastax.oss.pulsar.functions.transforms.Utils;
 import de.odysseus.el.tree.TreeBuilderException;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
@@ -60,12 +61,14 @@ public class JstEvaluatorTest {
             new Utils.TestContext(primitiveStringRecord, new HashMap<>()),
             primitiveStringRecord.getValue().getNativeObject());
 
-    long expectedNow = Instant.now().toEpochMilli();
-    long actualNow =
+    long expectedMillis = 123L;
+    Clock clock = Clock.fixed(Instant.ofEpochMilli(expectedMillis), ZoneOffset.UTC);
+    JstlFunctions.setClock(clock);
+    ;
+    long actualMillis =
         new JstlEvaluator<Long>("${fn:now()}", long.class).evaluate(primitiveStringContext);
 
-    assertTrue(actualNow >= expectedNow);
-    assertTrue(actualNow < expectedNow + 100L);
+    assertEquals(expectedMillis, actualMillis);
   }
 
   @Test
@@ -80,13 +83,15 @@ public class JstEvaluatorTest {
             new Utils.TestContext(primitiveStringRecord, new HashMap<>()),
             primitiveStringRecord.getValue().getNativeObject());
 
-    long expected = Instant.now().plusSeconds(-3333).toEpochMilli();
-    long actual =
+    long nowMillis = 5000L;
+    long millisToAdd = -3333L * 1000L;
+    Clock clock = Clock.fixed(Instant.ofEpochMilli(nowMillis), ZoneOffset.UTC);
+    JstlFunctions.setClock(clock);
+    long actualMillis =
         new JstlEvaluator<Long>("${fn:dateadd(fn:now(), -3333, 'seconds')}", long.class)
             .evaluate(primitiveStringContext);
 
-    assertTrue(actual >= expected);
-    assertTrue(actual < expected + 100L);
+    assertEquals(nowMillis + millisToAdd, actualMillis);
   }
 
   /** @return {"expression", "transform context"} */

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstEvaluatorTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstEvaluatorTest.java
@@ -150,37 +150,37 @@ public class JstEvaluatorTest {
       {"fn:concat(value, null)", primitiveStringContext, "test-message"},
       {"fn:concat(null, '-suffix')", primitiveStringContext, "-suffix"},
       {
-        "fn:dateadd('2017-01-02T00:01:02', 1, 'years')",
+        "fn:dateadd('2017-01-02T00:01:02Z', 1, 'years')",
         primitiveStringContext,
         Instant.parse("2018-01-02T00:01:02Z").toEpochMilli()
       },
       {
-        "fn:dateadd('2017-01-02T00:01:02', -1, 'months')",
+        "fn:dateadd('2017-01-02T00:01:02Z', -1, 'months')",
         primitiveStringContext,
         Instant.parse("2016-12-02T00:01:02Z").toEpochMilli()
       },
       {
-        "fn:dateadd('2017-01-02T00:01:02', 1, 'days')",
+        "fn:dateadd('2017-01-02T00:01:02Z', 1, 'days')",
         primitiveStringContext,
         Instant.parse("2017-01-03T00:01:02Z").toEpochMilli()
       },
       {
-        "fn:dateadd('2017-01-02T00:01:02', -1, 'hours')",
+        "fn:dateadd('2017-01-02T00:01:02Z', -1, 'hours')",
         primitiveStringContext,
         Instant.parse("2017-01-01T23:01:02Z").toEpochMilli()
       },
       {
-        "fn:dateadd('2017-01-02T00:01:02', 1, 'minutes')",
+        "fn:dateadd('2017-01-02T00:01:02Z', 1, 'minutes')",
         primitiveStringContext,
         Instant.parse("2017-01-02T00:02:02Z").toEpochMilli()
       },
       {
-        "fn:dateadd('2017-01-02T00:01:02', -1, 'seconds')",
+        "fn:dateadd('2017-01-02T00:01:02Z', -1, 'seconds')",
         primitiveStringContext,
         Instant.parse("2017-01-02T00:01:01Z").toEpochMilli()
       },
       {
-        "fn:dateadd('2017-01-02T00:01:02', 1, 'millis')",
+        "fn:dateadd('2017-01-02T00:01:02Z', 1, 'millis')",
         primitiveStringContext,
         Instant.parse("2017-01-02T00:01:02.001Z").toEpochMilli()
       },

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstEvaluatorTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstEvaluatorTest.java
@@ -22,6 +22,7 @@ import com.datastax.oss.pulsar.functions.transforms.Utils;
 import de.odysseus.el.tree.TreeBuilderException;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.HashMap;
 import org.apache.pulsar.client.api.Schema;
@@ -128,8 +129,8 @@ public class JstEvaluatorTest {
         new TransformContext(
             new Utils.TestContext(primitiveStringRecord, new HashMap<>()),
             primitiveStringRecord.getValue().getNativeObject());
-    Instant instant = Instant.parse("2017-01-02T00:01:02Z");
-    long millis = instant.toEpochMilli();
+    OffsetDateTime offsetDateTime = OffsetDateTime.parse("2017-01-02T00:01:02Z");
+    long millis = offsetDateTime.toInstant().toEpochMilli();
     return new Object[][] {
       {"fn:uppercase('test')", primitiveStringContext, "TEST"},
       {"fn:uppercase(value) == 'TEST-MESSAGE'", primitiveStringContext, true},
@@ -152,72 +153,72 @@ public class JstEvaluatorTest {
       {
         "fn:dateadd('2017-01-02T00:01:02Z', 1, 'years')",
         primitiveStringContext,
-        Instant.parse("2018-01-02T00:01:02Z").toEpochMilli()
+        OffsetDateTime.parse("2018-01-02T00:01:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd('2017-01-02T00:01:02Z', -1, 'months')",
         primitiveStringContext,
-        Instant.parse("2016-12-02T00:01:02Z").toEpochMilli()
+        OffsetDateTime.parse("2016-12-02T00:01:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd('2017-01-02T00:01:02Z', 1, 'days')",
         primitiveStringContext,
-        Instant.parse("2017-01-03T00:01:02Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-03T00:01:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd('2017-01-02T00:01:02Z', -1, 'hours')",
         primitiveStringContext,
-        Instant.parse("2017-01-01T23:01:02Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-01T23:01:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd('2017-01-02T00:01:02Z', 1, 'minutes')",
         primitiveStringContext,
-        Instant.parse("2017-01-02T00:02:02Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-02T00:02:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd('2017-01-02T00:01:02Z', -1, 'seconds')",
         primitiveStringContext,
-        Instant.parse("2017-01-02T00:01:01Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-02T00:01:01Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd('2017-01-02T00:01:02Z', 1, 'millis')",
         primitiveStringContext,
-        Instant.parse("2017-01-02T00:01:02.001Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-02T00:01:02.001Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd(" + millis + ", 1, 'years')",
         primitiveStringContext,
-        Instant.parse("2018-01-02T00:01:02Z").toEpochMilli()
+        OffsetDateTime.parse("2018-01-02T00:01:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd(" + millis + ", -1, 'months')",
         primitiveStringContext,
-        Instant.parse("2016-12-02T00:01:02Z").toEpochMilli()
+        OffsetDateTime.parse("2016-12-02T00:01:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd(" + millis + ", 1, 'days')",
         primitiveStringContext,
-        Instant.parse("2017-01-03T00:01:02Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-03T00:01:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd(" + millis + ", -1, 'hours')",
         primitiveStringContext,
-        Instant.parse("2017-01-01T23:01:02Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-01T23:01:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd(" + millis + ", 1, 'minutes')",
         primitiveStringContext,
-        Instant.parse("2017-01-02T00:02:02Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-02T00:02:02Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd(" + millis + ", -1, 'seconds')",
         primitiveStringContext,
-        Instant.parse("2017-01-02T00:01:01Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-02T00:01:01Z").toInstant().toEpochMilli()
       },
       {
         "fn:dateadd(" + millis + ", 1, 'millis')",
         primitiveStringContext,
-        Instant.parse("2017-01-02T00:01:02.001Z").toEpochMilli()
+        OffsetDateTime.parse("2017-01-02T00:01:02.001Z").toInstant().toEpochMilli()
       },
     };
   }

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
@@ -19,7 +19,9 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -105,10 +107,10 @@ public class JstlFunctionsTest {
 
   @Test
   void testNow() {
-    long minExpectedMillis = Instant.now().toEpochMilli();
-    long actualNow = JstlFunctions.now();
-    assertTrue(actualNow >= minExpectedMillis);
-    assertTrue(actualNow < minExpectedMillis + 100L);
+    long expectedMillis = 99L;
+    Clock clock = Clock.fixed(Instant.ofEpochMilli(expectedMillis), ZoneOffset.UTC);
+    JstlFunctions.setClock(clock);
+    assertEquals(expectedMillis, JstlFunctions.now());
   }
 
   @Test(dataProvider = "millisDateAddProvider")

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
@@ -168,7 +168,7 @@ public class JstlFunctionsTest {
    */
   @DataProvider(name = "isoDateAddProvider")
   public static Object[][] isoDateAddProvider() {
-    String isoDateTime = "2022-10-02T01:02:03";
+    String isoDateTime = "2022-10-02T01:02:03Z";
     Instant instant = Instant.parse("2022-10-02T01:02:03Z");
     return new Object[][] {
       {isoDateTime, 0, "years", instant.toEpochMilli()},

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
@@ -19,6 +19,8 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.time.Instant;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class JstlFunctionsTest {
@@ -87,15 +89,116 @@ public class JstlFunctionsTest {
     assertEquals("full text", JstlFunctions.concat("full ", "text"));
   }
 
+  @Test
   void testConcatInteger() {
     assertEquals("12", JstlFunctions.concat(1, 2));
     assertEquals("12", JstlFunctions.concat("1", 2));
     assertEquals("12", JstlFunctions.concat(1, "2"));
   }
 
+  @Test
   void testConcatNull() {
     assertEquals("text", JstlFunctions.concat(null, "text"));
     assertEquals("full ", JstlFunctions.concat("full ", null));
     assertEquals("", JstlFunctions.concat(null, null));
+  }
+
+  @Test
+  void testNow() {
+    long minExpectedMillis = Instant.now().toEpochMilli();
+    long actualNow = JstlFunctions.now();
+    assertTrue(actualNow >= minExpectedMillis);
+    assertTrue(actualNow < minExpectedMillis + 100L);
+  }
+
+  @Test(dataProvider = "millisDateAddProvider")
+  void testAddDateMillis(long input, int delta, String unit, long expected) {
+    assertEquals(expected, JstlFunctions.dateadd(input, delta, unit));
+  }
+
+  @Test(dataProvider = "isoDateAddProvider")
+  void testAddDateIso(String input, int delta, String unit, long expected) {
+    assertEquals(expected, JstlFunctions.dateadd(input, delta, unit));
+  }
+
+  @Test(
+    expectedExceptions = IllegalArgumentException.class,
+    expectedExceptionsMessageRegExp = "Invalid input type: Double\\..*"
+  )
+  void testInvalidAddDate() {
+    JstlFunctions.dateadd(7D, 0, "days");
+  }
+
+  /**
+   * @return {"input date (epoch millis or iso datetime string)", "delta", "unit", "expected value"}
+   */
+  @DataProvider(name = "millisDateAddProvider")
+  public static Object[][] millisDateAddProvider() {
+    Instant instant = Instant.parse("2022-10-02T01:02:03Z");
+    long millis = instant.toEpochMilli();
+    return new Object[][] {
+      {millis, 0, "years", instant.toEpochMilli()},
+      {millis, 5, "years", Instant.parse("2027-10-02T01:02:03Z").toEpochMilli()},
+      {millis, -3, "years", Instant.parse("2019-10-02T01:02:03Z").toEpochMilli()},
+      {millis, 0, "months", instant.toEpochMilli()},
+      {millis, 5, "months", Instant.parse("2023-03-02T01:02:03Z").toEpochMilli()},
+      {millis, -3, "months", Instant.parse("2022-07-02T01:02:03Z").toEpochMilli()},
+      {millis, 0, "days", instant.toEpochMilli()},
+      {millis, 5, "days", Instant.parse("2022-10-07T01:02:03Z").toEpochMilli()},
+      {millis, -3, "days", Instant.parse("2022-09-29T01:02:03Z").toEpochMilli()},
+      {millis, 0, "hours", instant.toEpochMilli()},
+      {millis, 5, "hours", Instant.parse("2022-10-02T06:02:03Z").toEpochMilli()},
+      {millis, -3, "hours", Instant.parse("2022-10-01T22:02:03Z").toEpochMilli()},
+      {millis, 0, "minutes", instant.toEpochMilli()},
+      {millis, 5, "minutes", Instant.parse("2022-10-02T01:07:03Z").toEpochMilli()},
+      {millis, -3, "minutes", Instant.parse("2022-10-02T00:59:03Z").toEpochMilli()},
+      {millis, 0, "seconds", instant.toEpochMilli()},
+      {millis, 5, "seconds", Instant.parse("2022-10-02T01:02:08Z").toEpochMilli()},
+      {millis, -3, "seconds", Instant.parse("2022-10-02T01:02:00Z").toEpochMilli()},
+      {millis, 0, "millis", instant.toEpochMilli()},
+      {millis, 5, "millis", Instant.parse("2022-10-02T01:02:03.005Z").toEpochMilli()},
+      {millis, -3, "millis", Instant.parse("2022-10-02T01:02:02.997Z").toEpochMilli()},
+    };
+  }
+
+  /**
+   * @return {"input date (epoch millis or iso datetime string)", "delta", "unit", "expected value"}
+   */
+  @DataProvider(name = "isoDateAddProvider")
+  public static Object[][] isoDateAddProvider() {
+    String isoDateTime = "2022-10-02T01:02:03";
+    Instant instant = Instant.parse("2022-10-02T01:02:03Z");
+    return new Object[][] {
+      {isoDateTime, 0, "years", instant.toEpochMilli()},
+      {isoDateTime, 5, "years", Instant.parse("2027-10-02T01:02:03Z").toEpochMilli()},
+      {isoDateTime, -3, "years", Instant.parse("2019-10-02T01:02:03Z").toEpochMilli()},
+      {isoDateTime, 0, "months", instant.toEpochMilli()},
+      {isoDateTime, 5, "months", Instant.parse("2023-03-02T01:02:03Z").toEpochMilli()},
+      {isoDateTime, -3, "months", Instant.parse("2022-07-02T01:02:03Z").toEpochMilli()},
+      {isoDateTime, 0, "days", instant.toEpochMilli()},
+      {isoDateTime, 5, "days", Instant.parse("2022-10-07T01:02:03Z").toEpochMilli()},
+      {isoDateTime, -3, "days", Instant.parse("2022-09-29T01:02:03Z").toEpochMilli()},
+      {isoDateTime, 0, "hours", instant.toEpochMilli()},
+      {isoDateTime, 5, "hours", Instant.parse("2022-10-02T06:02:03Z").toEpochMilli()},
+      {isoDateTime, -3, "hours", Instant.parse("2022-10-01T22:02:03Z").toEpochMilli()},
+      {isoDateTime, 0, "minutes", instant.toEpochMilli()},
+      {isoDateTime, 5, "minutes", Instant.parse("2022-10-02T01:07:03Z").toEpochMilli()},
+      {isoDateTime, -3, "minutes", Instant.parse("2022-10-02T00:59:03Z").toEpochMilli()},
+      {isoDateTime, 0, "seconds", instant.toEpochMilli()},
+      {isoDateTime, 5, "seconds", Instant.parse("2022-10-02T01:02:08Z").toEpochMilli()},
+      {isoDateTime, -3, "seconds", Instant.parse("2022-10-02T01:02:00Z").toEpochMilli()},
+      {isoDateTime, 0, "millis", instant.toEpochMilli()},
+      {isoDateTime, 5, "millis", Instant.parse("2022-10-02T01:02:03.005Z").toEpochMilli()},
+      {isoDateTime, -3, "millis", Instant.parse("2022-10-02T01:02:02.997Z").toEpochMilli()},
+    };
+  }
+
+  @Test(
+    expectedExceptions = IllegalArgumentException.class,
+    expectedExceptionsMessageRegExp =
+        "Invalid unit: lightyear. Should be one of \\[hours, seconds, months, minutes, days, millis, years\\]"
+  )
+  void testAddDateInvalidUnit() {
+    JstlFunctions.dateadd(0L, 0, "lightyear");
   }
 }

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
@@ -20,7 +20,9 @@ import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -118,8 +120,13 @@ public class JstlFunctionsTest {
     assertEquals(expected, JstlFunctions.dateadd(input, delta, unit));
   }
 
-  @Test(dataProvider = "isoDateAddProvider")
-  void testAddDateIso(String input, int delta, String unit, long expected) {
+  @Test(dataProvider = "utcDateAddProvider")
+  void testAddDateUTC(String input, int delta, String unit, long expected) {
+    assertEquals(expected, JstlFunctions.dateadd(input, delta, unit));
+  }
+
+  @Test(dataProvider = "nonUtcDateAddProvider")
+  void testAddDateNonUTC(String input, int delta, String unit, long expected) {
     assertEquals(expected, JstlFunctions.dateadd(input, delta, unit));
   }
 
@@ -131,67 +138,168 @@ public class JstlFunctionsTest {
     JstlFunctions.dateadd(7D, 0, "days");
   }
 
-  /**
-   * @return {"input date (epoch millis or iso datetime string)", "delta", "unit", "expected value"}
-   */
+  /** @return {"input date in epoch millis", "delta", "unit", "expected value (in epoch millis)"} */
   @DataProvider(name = "millisDateAddProvider")
   public static Object[][] millisDateAddProvider() {
-    Instant instant = Instant.parse("2022-10-02T01:02:03Z");
-    long millis = instant.toEpochMilli();
+    OffsetDateTime offsetDateTime = OffsetDateTime.parse("2022-10-02T01:02:03Z");
+    long millis = offsetDateTime.toInstant().toEpochMilli();
     return new Object[][] {
-      {millis, 0, "years", instant.toEpochMilli()},
+      {millis, 0, "years", offsetDateTime.toInstant().toEpochMilli()},
       {millis, 5, "years", Instant.parse("2027-10-02T01:02:03Z").toEpochMilli()},
       {millis, -3, "years", Instant.parse("2019-10-02T01:02:03Z").toEpochMilli()},
-      {millis, 0, "months", instant.toEpochMilli()},
+      {millis, 0, "months", offsetDateTime.toInstant().toEpochMilli()},
       {millis, 5, "months", Instant.parse("2023-03-02T01:02:03Z").toEpochMilli()},
       {millis, -3, "months", Instant.parse("2022-07-02T01:02:03Z").toEpochMilli()},
-      {millis, 0, "days", instant.toEpochMilli()},
+      {millis, 0, "days", offsetDateTime.toInstant().toEpochMilli()},
       {millis, 5, "days", Instant.parse("2022-10-07T01:02:03Z").toEpochMilli()},
       {millis, -3, "days", Instant.parse("2022-09-29T01:02:03Z").toEpochMilli()},
-      {millis, 0, "hours", instant.toEpochMilli()},
+      {millis, 0, "hours", offsetDateTime.toInstant().toEpochMilli()},
       {millis, 5, "hours", Instant.parse("2022-10-02T06:02:03Z").toEpochMilli()},
       {millis, -3, "hours", Instant.parse("2022-10-01T22:02:03Z").toEpochMilli()},
-      {millis, 0, "minutes", instant.toEpochMilli()},
+      {millis, 0, "minutes", offsetDateTime.toInstant().toEpochMilli()},
       {millis, 5, "minutes", Instant.parse("2022-10-02T01:07:03Z").toEpochMilli()},
       {millis, -3, "minutes", Instant.parse("2022-10-02T00:59:03Z").toEpochMilli()},
-      {millis, 0, "seconds", instant.toEpochMilli()},
+      {millis, 0, "seconds", offsetDateTime.toInstant().toEpochMilli()},
       {millis, 5, "seconds", Instant.parse("2022-10-02T01:02:08Z").toEpochMilli()},
       {millis, -3, "seconds", Instant.parse("2022-10-02T01:02:00Z").toEpochMilli()},
-      {millis, 0, "millis", instant.toEpochMilli()},
+      {millis, 0, "millis", offsetDateTime.toInstant().toEpochMilli()},
       {millis, 5, "millis", Instant.parse("2022-10-02T01:02:03.005Z").toEpochMilli()},
       {millis, -3, "millis", Instant.parse("2022-10-02T01:02:02.997Z").toEpochMilli()},
     };
   }
 
   /**
-   * @return {"input date (epoch millis or iso datetime string)", "delta", "unit", "expected value"}
+   * @return {"input date in rfc 3339 format", "delta", "unit", "expected value (in epoch millis)"}
    */
-  @DataProvider(name = "isoDateAddProvider")
-  public static Object[][] isoDateAddProvider() {
-    String isoDateTime = "2022-10-02T01:02:03Z";
-    Instant instant = Instant.parse("2022-10-02T01:02:03Z");
+  @DataProvider(name = "utcDateAddProvider")
+  public static Object[][] utcDateAddProvider() {
+    String utcDateTime = "2022-10-02T01:02:03Z";
+    OffsetDateTime offsetDateTime = OffsetDateTime.parse("2022-10-02T01:02:03Z");
     return new Object[][] {
-      {isoDateTime, 0, "years", instant.toEpochMilli()},
-      {isoDateTime, 5, "years", Instant.parse("2027-10-02T01:02:03Z").toEpochMilli()},
-      {isoDateTime, -3, "years", Instant.parse("2019-10-02T01:02:03Z").toEpochMilli()},
-      {isoDateTime, 0, "months", instant.toEpochMilli()},
-      {isoDateTime, 5, "months", Instant.parse("2023-03-02T01:02:03Z").toEpochMilli()},
-      {isoDateTime, -3, "months", Instant.parse("2022-07-02T01:02:03Z").toEpochMilli()},
-      {isoDateTime, 0, "days", instant.toEpochMilli()},
-      {isoDateTime, 5, "days", Instant.parse("2022-10-07T01:02:03Z").toEpochMilli()},
-      {isoDateTime, -3, "days", Instant.parse("2022-09-29T01:02:03Z").toEpochMilli()},
-      {isoDateTime, 0, "hours", instant.toEpochMilli()},
-      {isoDateTime, 5, "hours", Instant.parse("2022-10-02T06:02:03Z").toEpochMilli()},
-      {isoDateTime, -3, "hours", Instant.parse("2022-10-01T22:02:03Z").toEpochMilli()},
-      {isoDateTime, 0, "minutes", instant.toEpochMilli()},
-      {isoDateTime, 5, "minutes", Instant.parse("2022-10-02T01:07:03Z").toEpochMilli()},
-      {isoDateTime, -3, "minutes", Instant.parse("2022-10-02T00:59:03Z").toEpochMilli()},
-      {isoDateTime, 0, "seconds", instant.toEpochMilli()},
-      {isoDateTime, 5, "seconds", Instant.parse("2022-10-02T01:02:08Z").toEpochMilli()},
-      {isoDateTime, -3, "seconds", Instant.parse("2022-10-02T01:02:00Z").toEpochMilli()},
-      {isoDateTime, 0, "millis", instant.toEpochMilli()},
-      {isoDateTime, 5, "millis", Instant.parse("2022-10-02T01:02:03.005Z").toEpochMilli()},
-      {isoDateTime, -3, "millis", Instant.parse("2022-10-02T01:02:02.997Z").toEpochMilli()},
+      {utcDateTime, 0, "years", offsetDateTime.toInstant().toEpochMilli()},
+      {utcDateTime, 5, "years", Instant.parse("2027-10-02T01:02:03Z").toEpochMilli()},
+      {utcDateTime, -3, "years", Instant.parse("2019-10-02T01:02:03Z").toEpochMilli()},
+      {utcDateTime, 0, "months", offsetDateTime.toInstant().toEpochMilli()},
+      {utcDateTime, 5, "months", Instant.parse("2023-03-02T01:02:03Z").toEpochMilli()},
+      {utcDateTime, -3, "months", Instant.parse("2022-07-02T01:02:03Z").toEpochMilli()},
+      {utcDateTime, 0, "days", offsetDateTime.toInstant().toEpochMilli()},
+      {utcDateTime, 5, "days", Instant.parse("2022-10-07T01:02:03Z").toEpochMilli()},
+      {utcDateTime, -3, "days", Instant.parse("2022-09-29T01:02:03Z").toEpochMilli()},
+      {utcDateTime, 0, "hours", offsetDateTime.toInstant().toEpochMilli()},
+      {utcDateTime, 5, "hours", Instant.parse("2022-10-02T06:02:03Z").toEpochMilli()},
+      {utcDateTime, -3, "hours", Instant.parse("2022-10-01T22:02:03Z").toEpochMilli()},
+      {utcDateTime, 0, "minutes", offsetDateTime.toInstant().toEpochMilli()},
+      {utcDateTime, 5, "minutes", Instant.parse("2022-10-02T01:07:03Z").toEpochMilli()},
+      {utcDateTime, -3, "minutes", Instant.parse("2022-10-02T00:59:03Z").toEpochMilli()},
+      {utcDateTime, 0, "seconds", offsetDateTime.toInstant().toEpochMilli()},
+      {utcDateTime, 5, "seconds", Instant.parse("2022-10-02T01:02:08Z").toEpochMilli()},
+      {utcDateTime, -3, "seconds", Instant.parse("2022-10-02T01:02:00Z").toEpochMilli()},
+      {utcDateTime, 0, "millis", offsetDateTime.toInstant().toEpochMilli()},
+      {utcDateTime, 5, "millis", Instant.parse("2022-10-02T01:02:03.005Z").toEpochMilli()},
+      {utcDateTime, -3, "millis", Instant.parse("2022-10-02T01:02:02.997Z").toEpochMilli()},
+    };
+  }
+
+  /**
+   * @return {"input date in rfc 3339 format)", "delta", "unit", "expected value (in epoch millis)"}
+   */
+  @DataProvider(name = "nonUtcDateAddProvider")
+  public static Object[][] nonUtcDateAddProvider() {
+    String nonUtcDateTime = "2022-10-02T01:02:03+02:00";
+    long twoHoursMillis = Duration.ofHours(2).toMillis();
+    OffsetDateTime offsetDateTime = OffsetDateTime.parse("2022-10-02T01:02:03Z");
+    return new Object[][] {
+      {nonUtcDateTime, 0, "years", offsetDateTime.toInstant().toEpochMilli() - twoHoursMillis},
+      {
+        nonUtcDateTime,
+        5,
+        "years",
+        Instant.parse("2027-10-02T01:02:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {
+        nonUtcDateTime,
+        -3,
+        "years",
+        Instant.parse("2019-10-02T01:02:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {nonUtcDateTime, 0, "months", offsetDateTime.toInstant().toEpochMilli() - twoHoursMillis},
+      {
+        nonUtcDateTime,
+        5,
+        "months",
+        Instant.parse("2023-03-02T01:02:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {
+        nonUtcDateTime,
+        -3,
+        "months",
+        Instant.parse("2022-07-02T01:02:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {nonUtcDateTime, 0, "days", offsetDateTime.toInstant().toEpochMilli() - twoHoursMillis},
+      {
+        nonUtcDateTime,
+        5,
+        "days",
+        Instant.parse("2022-10-07T01:02:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {
+        nonUtcDateTime,
+        -3,
+        "days",
+        Instant.parse("2022-09-29T01:02:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {nonUtcDateTime, 0, "hours", offsetDateTime.toInstant().toEpochMilli() - twoHoursMillis},
+      {
+        nonUtcDateTime,
+        5,
+        "hours",
+        Instant.parse("2022-10-02T06:02:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {
+        nonUtcDateTime,
+        -3,
+        "hours",
+        Instant.parse("2022-10-01T22:02:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {nonUtcDateTime, 0, "minutes", offsetDateTime.toInstant().toEpochMilli() - twoHoursMillis},
+      {
+        nonUtcDateTime,
+        5,
+        "minutes",
+        Instant.parse("2022-10-02T01:07:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {
+        nonUtcDateTime,
+        -3,
+        "minutes",
+        Instant.parse("2022-10-02T00:59:03Z").toEpochMilli() - twoHoursMillis
+      },
+      {nonUtcDateTime, 0, "seconds", offsetDateTime.toInstant().toEpochMilli() - twoHoursMillis},
+      {
+        nonUtcDateTime,
+        5,
+        "seconds",
+        Instant.parse("2022-10-02T01:02:08Z").toEpochMilli() - twoHoursMillis
+      },
+      {
+        nonUtcDateTime,
+        -3,
+        "seconds",
+        Instant.parse("2022-10-02T01:02:00Z").toEpochMilli() - twoHoursMillis
+      },
+      {nonUtcDateTime, 0, "millis", offsetDateTime.toInstant().toEpochMilli() - twoHoursMillis},
+      {
+        nonUtcDateTime,
+        5,
+        "millis",
+        Instant.parse("2022-10-02T01:02:03.005Z").toEpochMilli() - twoHoursMillis
+      },
+      {
+        nonUtcDateTime,
+        -3,
+        "millis",
+        Instant.parse("2022-10-02T01:02:02.997Z").toEpochMilli() - twoHoursMillis
+      },
     };
   }
 

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlFunctionsTest.java
@@ -306,7 +306,7 @@ public class JstlFunctionsTest {
   @Test(
     expectedExceptions = IllegalArgumentException.class,
     expectedExceptionsMessageRegExp =
-        "Invalid unit: lightyear. Should be one of \\[hours, seconds, months, minutes, days, millis, years\\]"
+        "Invalid unit: lightyear. Should be one of \\[years, months, days, hours, minutes, seconds, millis\\]"
   )
   void testAddDateInvalidUnit() {
     JstlFunctions.dateadd(0L, 0, "lightyear");


### PR DESCRIPTION
Fixes: #20 

This patch adds support for the following date/time types:
* `Date`:  Contains date info only, represented as ISO 8601 date like '2022-10-02'
* `Time`: Contains time info only, represented as ISO 8601 time like '23:00:00'
* `OffsetDateTime`: Full date time info,  represented as UTC ISO 3339 like '2011-12-03T10:15:30Z' or '2011-12-03T10:15:30+00:00' or '2011-12-03T10:15:30+02:00'
* Added the following utility date functions:
  * now() return the epoch millis as of now
  * dateadd(input , delta, unit) where
    * input: Is either a Long representing epoch millis or a string representing ISO date like '2011-12-03T10:15:30'
    * delta: As int representing how many units to add or subtract form the input date. 
    * unit: could be one of `[years, months, days, hours, minutes, seconds, millis]`

Implementation note:
* The JSTL evaluator maps the types `Date`, `Time`, `OffsetDateTime` to `java.time.LocalDate`, `java.time.LocalTime`, `java.time.Instant` respectively. 
* In Avro, the types `Date`, `Time`, `OffsetDateTime` are converted to logical times `date`, `time-millis`, timestamp-millis respectively 

