### PR TITLE
Add support for header properties compute

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeFieldStep.java
@@ -54,6 +54,12 @@ public class ComputeFieldStep implements TransformStep {
     computeHeaderFields(
         fields.stream().filter(f -> "header".equals(f.getScope())).collect(Collectors.toList()),
         transformContext);
+    computeHeaderPropertiesFields(
+        fields
+            .stream()
+            .filter(f -> "header.properties".equals(f.getScope()))
+            .collect(Collectors.toList()),
+        transformContext);
   }
 
   public void computeValueFields(List<ComputeField> fields, TransformContext context) {
@@ -95,6 +101,15 @@ public class ComputeFieldStep implements TransformStep {
               throw new IllegalArgumentException("Invalid compute field name: " + field.getName());
           }
         });
+  }
+
+  public void computeHeaderPropertiesFields(List<ComputeField> fields, TransformContext context) {
+    Map<String, String> properties =
+        fields
+            .stream()
+            .map(field -> Map.entry(field.getName(), validateAndGetString(field, context)))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    context.setProperties(properties);
   }
 
   private String validateAndGetString(ComputeField field, TransformContext context) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/ComputeField.java
@@ -87,6 +87,10 @@ public class ComputeField {
         String[] nameParts = this.scopedName.split("\\.", 2);
         this.scope = nameParts[0];
         this.name = nameParts[1];
+      } else if (this.scopedName.startsWith("properties.")) {
+        String[] nameParts = this.scopedName.split("\\.", 2);
+        this.scope = "header.properties";
+        this.name = nameParts[1];
       } else if (validComputeHeaders.contains(this.scopedName)) {
         this.scope = "header";
         this.name = this.scopedName;
@@ -94,7 +98,7 @@ public class ComputeField {
         throw new IllegalArgumentException(
             String.format(
                 "Invalid compute field name: %s. "
-                    + "It should be prefixed with 'key.' or 'value.' or be one of %s",
+                    + "It should be prefixed with 'key.' or 'value.' or 'properties.' or be one of %s",
                 this.scopedName, validComputeHeaders));
       }
     }


### PR DESCRIPTION
(Fixes #27)

This patch adds support for computing custom fields on the properties Key/Value headers. 

**Implementation note:**
The behavior of the transform context is change from overwriting the current record props to merging - only computed props that have matching keys will overwrite existing ones.