### PR TITLE
Handle avro Utf8 type in the compute step

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
@@ -17,6 +17,8 @@ package com.datastax.oss.pulsar.functions.transforms.jstl;
 
 import de.odysseus.el.misc.TypeConverter;
 import de.odysseus.el.misc.TypeConverterImpl;
+import org.apache.avro.util.Utf8;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
@@ -39,6 +41,9 @@ public class CustomTypeConverter implements TypeConverter {
       return (T) LocalTime.parse(o.toString());
     } else if (aClass == OffsetDateTime.class) {
       return (T) OffsetDateTime.parse(o.toString());
+    }
+    if (o instanceof org.apache.avro.util.Utf8) {
+      o = o.toString();
     }
     return typeConverter.convert(o, aClass);
   }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverter.java
@@ -17,8 +17,6 @@ package com.datastax.oss.pulsar.functions.transforms.jstl;
 
 import de.odysseus.el.misc.TypeConverter;
 import de.odysseus.el.misc.TypeConverterImpl;
-import org.apache.avro.util.Utf8;
-
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
@@ -22,6 +22,8 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+
+import org.apache.avro.util.Utf8;
 import org.testng.annotations.Test;
 
 public class CustomTypeConverterTest {
@@ -44,6 +46,9 @@ public class CustomTypeConverterTest {
   void testNonNullConversion() {
     CustomTypeConverter converter = new CustomTypeConverter();
     assertEquals(converter.convert("test", String.class), "test");
+    assertEquals((int) converter.convert("1", int.class), 1);
+    assertEquals(converter.convert(new Utf8("test"), String.class), "test");
+    assertEquals((int) converter.convert(new Utf8("1"), int.class), 1);
     assertEquals((int) converter.convert(1, int.class), 1);
     assertEquals((long) converter.convert(1L, long.class), 1L);
     assertEquals(converter.convert(1.3F, float.class), 1.3F);

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
@@ -22,7 +22,6 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-
 import org.apache.avro.util.Utf8;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
Avro Utf8 is not handled in the compute step. 
```
2022-10-19T11:01:11,334+0000 [public/default/cassandra-sink-0] WARN  org.apache.pulsar.functions.instance.JavaInstanceRunnable - Encountered exception when processing message PulsarRecord(topicName=Optional[persistent://public/default/dbserver1.public.pulsar_source_table], partition=0, message=Optional[org.apache.pulsar.client.impl.MessageImpl@e8bf0dd], schema=KeyValueSchema(SEPARATED,org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema@716fe484,org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema@1b858f4e), failFunction=org.apache.pulsar.functions.source.PulsarSource$$Lambda$503/0x0000000840684040@2ddcc8ef, ackFunction=org.apache.pulsar.functions.source.PulsarSource$$Lambda$502/0x0000000840684c40@290cfaee)
javax.el.ELException: Cannot coerce '10' of class org.apache.avro.util.Utf8 to class java.lang.Integer (incompatible type)
        at de.odysseus.el.misc.TypeConverterImpl.coerceToInteger(TypeConverterImpl.java:201) ~[?:?]
        at de.odysseus.el.misc.TypeConverterImpl.coerceToType(TypeConverterImpl.java:321) ~[?:?]
        at de.odysseus.el.misc.TypeConverterImpl.convert(TypeConverterImpl.java:365) ~[?:?]
        at com.datastax.oss.pulsar.functions.transforms.jstl.CustomTypeConverter.convert(CustomTypeConverter.java:43) ~[?:?]
        at de.odysseus.el.tree.Bindings.convert(Bindings.java:138) ~[?:?]
        at de.odysseus.el.tree.impl.ast.AstNode.getValue(AstNode.java:33) ~[?:?]
        at de.odysseus.el.TreeValueExpression.getValue(TreeValueExpression.java:122) ~[?:?]
        at com.datastax.oss.pulsar.functions.transforms.jstl.JstlEvaluator.evaluate(JstlEvaluator.java:93) ~[?:?]
        at com.datastax.oss.pulsar.functions.transforms.ComputeStep.computeFields(ComputeStep.java:180) ~[?:?]
        at com.datastax.oss.pulsar.functions.transforms.ComputeStep.computeValueFields(ComputeStep.java:74) ~[?:?]
        at com.datastax.oss.pulsar.functions.transforms.ComputeStep.process(ComputeStep.java:57) ~[?:?]
        at com.datastax.oss.pulsar.functions.transforms.TransformFunction.process(TransformFunction.java:259) ~[?:?]
        at com.datastax.oss.pulsar.functions.transforms.TransformFunction.process(TransformFunction.java:249) ~[?:?]
        at com.datastax.oss.pulsar.functions.transforms.TransformFunction.process(TransformFunction.java:121) ~[?:?]
        at org.apache.pulsar.functions.instance.JavaInstance.handleMessage(JavaInstance.java:94) ~[com.datastax.oss-pulsar-functions-instance-2.10.2.3.jar:2.10.2.3]
        at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:321) ~[com.datastax.oss-pulsar-functions-instance-2.10.2.3.jar:2.10.2.3]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```