### PR TITLE
Handle flatten fields with nullable parents

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
@@ -170,17 +170,16 @@ public class FlattenStep implements TransformStep {
       return null;
     }
 
-    if (schema.getField(name).schema().isUnion()) {
-      for (org.apache.avro.Schema s : schema.getField(name).schema().getTypes()) {
+    org.apache.avro.Schema fieldSchema = schema.getField(name).schema();
+    if (fieldSchema.isUnion()) {
+      for (org.apache.avro.Schema s : fieldSchema.getTypes()) {
         if (s.getType() == org.apache.avro.Schema.Type.RECORD) {
           return s;
         }
       }
     }
 
-    return schema.getField(name).schema().getType() == org.apache.avro.Schema.Type.RECORD
-        ? schema.getField(name).schema()
-        : null;
+    return fieldSchema.getType() == org.apache.avro.Schema.Type.RECORD ? fieldSchema : null;
   }
 
   /**

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/FlattenStep.java
@@ -18,8 +18,10 @@ package com.datastax.oss.pulsar.functions.transforms;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.pulsar.client.api.Schema;
@@ -31,6 +33,8 @@ public class FlattenStep implements TransformStep {
   // TODO: Microbenchmark the flatten algorithm for performance optimization
   // TODO: Validate flatten delimiter
   // TODO: Add integration test
+
+  public static final String AVRO_READ_OFFSET_PROP = "__AVRO_READ_OFFSET__";
 
   private static final String DEFAULT_DELIMITER = "_"; // '.' in not valid in AVRO field names
 
@@ -88,7 +92,8 @@ public class FlattenStep implements TransformStep {
     List<FieldValuePair> flattenedFields = new ArrayList<>();
     org.apache.avro.Schema originalSchema = record.getSchema();
     for (org.apache.avro.Schema.Field field : originalSchema.getFields()) {
-      flattenedFields.addAll(flattenField(record, field, ""));
+      flattenedFields.addAll(
+          flattenField(record, record.getSchema(), field, field.schema().isNullable(), ""));
     }
 
     return flattenedFields;
@@ -97,49 +102,102 @@ public class FlattenStep implements TransformStep {
   org.apache.avro.Schema buildFlattenedSchema(
       GenericRecord record, List<org.apache.avro.Schema.Field> flattenedFields) {
     org.apache.avro.Schema originalSchema = record.getSchema();
-
-    return org.apache.avro.Schema.createRecord(
-        originalSchema.getName(),
-        originalSchema.getDoc(),
-        originalSchema.getNamespace(),
-        false,
-        flattenedFields);
+    org.apache.avro.Schema flattenedSchema =
+        org.apache.avro.Schema.createRecord(
+            originalSchema.getName(),
+            originalSchema.getDoc(),
+            originalSchema.getNamespace(),
+            false,
+            flattenedFields);
+    originalSchema
+        .getObjectProps()
+        .entrySet()
+        .stream()
+        .filter(e -> !AVRO_READ_OFFSET_PROP.equals(e.getKey()))
+        .forEach(e -> flattenedSchema.addProp(e.getKey(), e.getValue()));
+    return flattenedSchema;
   }
 
+  /**
+   * @param record the record that contains the field to be flattened. Each recursive call will pass
+   *     the record one level deeper. At any level, the field could become null.
+   * @param schema the schema of the record that contains the field to be flattened. Each recursive
+   *     call will pass the schema one level deeper. At any level, the schema should exist.
+   * @param field the field to be flattened
+   * @param nullable true if the current field schema is nullable, this has to be passed all the way
+   *     to the last nested level because anytime one of the ancestors is null, the flattened field
+   *     schema could be null even if it is not nullable on the original schema
+   * @param flattenedFieldName the field name that is built incrementally with each recursive call.
+   * @return flattened key/value pairs.
+   */
   List<FieldValuePair> flattenField(
-      GenericRecord record, org.apache.avro.Schema.Field field, String flattenedFieldName) {
+      @Nullable GenericRecord record,
+      org.apache.avro.Schema schema,
+      org.apache.avro.Schema.Field field,
+      boolean nullable,
+      String flattenedFieldName) {
     List<FieldValuePair> flattenedFields = new ArrayList<>();
     // Because of UNION schemas, we cannot tell for sure if the current field is a record, so we
     // have to use reflection
-    if (record.get(field.name()) instanceof GenericRecord) {
-      GenericRecord genericRecord = (GenericRecord) record.get(field.name());
-      for (org.apache.avro.Schema.Field nestedField : genericRecord.getSchema().getFields()) {
+    org.apache.avro.Schema recordSchema = getRecordSchema(schema, field.name());
+    if (recordSchema != null) {
+      for (org.apache.avro.Schema.Field nestedField : recordSchema.getFields()) {
+        GenericRecord genericRecord =
+            record == null ? null : (GenericRecord) record.get(field.name());
         flattenedFields.addAll(
             flattenField(
-                genericRecord, nestedField, flattenedFieldName + field.name() + delimiter));
+                genericRecord,
+                recordSchema,
+                nestedField,
+                nullable || nestedField.schema().isNullable(),
+                flattenedFieldName + field.name() + delimiter));
       }
 
       return flattenedFields;
     }
 
     org.apache.avro.Schema.Field flattenedField =
-        createField(field, flattenedFieldName + field.name());
-    FieldValuePair fieldValuePair = new FieldValuePair(flattenedField, record.get(field.name()));
+        createField(field, flattenedFieldName + field.name(), nullable);
+    FieldValuePair fieldValuePair =
+        new FieldValuePair(flattenedField, record == null ? null : record.get(field.name()));
     flattenedFields.add(fieldValuePair);
 
     return flattenedFields;
+  }
+
+  private org.apache.avro.Schema getRecordSchema(org.apache.avro.Schema schema, String name) {
+    if (schema.getType() != org.apache.avro.Schema.Type.RECORD) {
+      return null;
+    }
+
+    if (schema.getField(name).schema().isUnion()) {
+      for (org.apache.avro.Schema s : schema.getField(name).schema().getTypes()) {
+        if (s.getType() == org.apache.avro.Schema.Type.RECORD) {
+          return s;
+        }
+      }
+    }
+
+    return schema.getField(name).schema().getType() == org.apache.avro.Schema.Type.RECORD
+        ? schema.getField(name).schema()
+        : null;
   }
 
   /**
    * Creates a new Field instance with the same schema, doc, defaultValue, and order as field has
    * with changing the name to the specified one. It also copies all the props and aliases.
    */
-  org.apache.avro.Schema.Field createField(org.apache.avro.Schema.Field field, String name) {
+  org.apache.avro.Schema.Field createField(
+      org.apache.avro.Schema.Field field, String name, boolean nullable) {
+    org.apache.avro.Schema newSchema = field.schema();
+    if (nullable && !newSchema.isNullable()) {
+      newSchema = SchemaBuilder.unionOf().nullType().and().type(newSchema).endUnion();
+    }
     org.apache.avro.Schema.Field newField =
         new org.apache.avro.Schema.Field(
-            name, field.schema(), field.doc(), field.defaultVal(), field.order());
+            name, newSchema, field.doc(), field.defaultVal(), field.order());
     newField.putAll(field);
-    field.aliases().forEach(field::addAlias);
+    field.aliases().forEach(newField::addAlias);
 
     return newField;
   }


### PR DESCRIPTION
fixes #33 

The main bugs fixed:
1. When generating the flattened field, if any parent field schema is nullable, mark the flattened field schema as nullable because at runtime, any ancestor could be null.
2. Use the original schema to traverse the recursion tree and avoid reflection on the actual GenericRecord value because if this was null, it'll cause the final flattened schema to be trimmed at the null levels prematurely. In other words, decouple the traversal of the schema from the the fields value.
3. Fix issues an issue in aliases copy
4. For now, skip copying the `__AVRO_READ_OFFSET__` property, It causes issues when the input schema is key/value, but the flatten is called only on the key or value part. Need more analysis about the usage of  `__AVRO_READ_OFFSET__`