### PR TITLE
Coerce Date to epoch days

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeStep.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import org.apache.avro.LogicalType;
@@ -49,7 +48,6 @@ import org.apache.avro.generic.GenericRecordBuilder;
 @Builder
 public class ComputeStep implements TransformStep {
 
-  public static final long MILLIS_PER_DAY = TimeUnit.DAYS.toMillis(1);
   @Builder.Default private final List<ComputeField> fields = new ArrayList<>();
   private final Map<org.apache.avro.Schema, org.apache.avro.Schema> keySchemaCache =
       new ConcurrentHashMap<>();
@@ -292,9 +290,7 @@ public class ComputeStep implements TransformStep {
 
   private Integer getAvroDate(Object value, LogicalType logicalType) {
     validateLogicalType(value, logicalType, Date.class, LocalDate.class);
-    return (value instanceof LocalDate)
-        ? (int) ((LocalDate) value).toEpochDay()
-        : (int) (((Date) value).getTime() / MILLIS_PER_DAY);
+    return CustomTypeConverter.INSTANCE.convert(value, Integer.class);
   }
 
   private Integer getAvroTimeMillis(Object value, LogicalType logicalType) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTypeConverter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTypeConverter.java
@@ -31,6 +31,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.avro.util.Utf8;
 import org.apache.el.util.MessageFactory;
 import org.apache.pulsar.client.api.Schema;
@@ -41,6 +42,7 @@ import org.apache.pulsar.client.api.Schema;
  */
 public class JstlTypeConverter extends TypeConverter {
   public static final JstlTypeConverter INSTANCE = new JstlTypeConverter();
+  public static final long MILLIS_PER_DAY = TimeUnit.DAYS.toMillis(1);
 
   @SuppressFBWarnings("NP_BOOLEAN_RETURN_NULL")
   protected Boolean coerceToBoolean(Object value) {
@@ -88,8 +90,14 @@ public class JstlTypeConverter extends TypeConverter {
     if (value instanceof Time) {
       return ((Time) value).toLocalTime().toNanoOfDay() / 1_000_000;
     }
+    if (value instanceof Timestamp) {
+      return ((Timestamp) value).getTime();
+    }
     if (value instanceof Date) {
-      return ((Date) value).getTime();
+      return ((Date) value).getTime() / MILLIS_PER_DAY;
+    }
+    if (value instanceof LocalDate) {
+      return ((LocalDate) value).toEpochDay();
     }
     if (value instanceof byte[]) {
       return Schema.INT64.decode((byte[]) value);
@@ -106,6 +114,12 @@ public class JstlTypeConverter extends TypeConverter {
     }
     if (value instanceof Time) {
       return (int) (((Time) value).toLocalTime().toNanoOfDay() / 1_000_000);
+    }
+    if (value instanceof Date) {
+      return (int) (((Date) value).getTime() / MILLIS_PER_DAY);
+    }
+    if (value instanceof LocalDate) {
+      return (int) ((LocalDate) value).toEpochDay();
     }
     if (value instanceof byte[]) {
       return Schema.INT32.decode((byte[]) value);

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/CustomTypeConverterTest.java
@@ -71,6 +71,7 @@ public class CustomTypeConverterTest {
     long midnightMillis = 1672617600000L;
     long timeMillis = 83045000L;
     double timeMillisWithNanos = 83045000.000006D;
+    long epochDays = 19359L;
     Date date = new Date(dateTimeMillis);
     Instant instant = Instant.ofEpochSecond(1672700645, 6);
     Timestamp timestamp = Timestamp.from(instant);
@@ -168,14 +169,14 @@ public class CustomTypeConverterTest {
       {longValue, Long.class, longValue},
       {floatValue, Long.class, longValue},
       {doubleValue, Long.class, longValue},
-      {date, Long.class, dateTimeMillis},
+      {date, Long.class, epochDays},
       {timestamp, Long.class, dateTimeMillis},
       {time, Long.class, timeMillis},
       {localDateTime, Long.class, dateTimeMillis},
       {instant, Long.class, dateTimeMillis},
       {offsetDateTime, Long.class, dateTimeMillis},
       {localTime, Long.class, timeMillis},
-      {localDate, Long.class, midnightMillis},
+      {localDate, Long.class, epochDays},
 
       // Float
       {Schema.FLOAT.encode(floatValue), Float.class, floatValue},


### PR DESCRIPTION
Convert `j.u.Date` to epoch days when applicable. This way it is consistent with AVRO's date logical type.