### PR TITLE
Fix resolving AVRO logical types in JstlTransformContextAdapter

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ComputeStep.java
@@ -20,6 +20,7 @@ import static org.apache.pulsar.common.schema.SchemaType.AVRO;
 import com.datastax.oss.pulsar.functions.transforms.jstl.JstlTypeConverter;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeField;
 import com.datastax.oss.pulsar.functions.transforms.model.ComputeFieldType;
+import com.datastax.oss.pulsar.functions.transforms.util.AvroUtil;
 import java.nio.ByteBuffer;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -32,7 +33,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -265,8 +265,8 @@ public class ComputeStep implements TransformStep {
     if (value instanceof Byte || value instanceof Short) {
       return ((Number) value).intValue();
     }
-
-    LogicalType logicalType = getLogicalType(schema);
+    
+    LogicalType logicalType = AvroUtil.getLogicalType(schema);
     if (logicalType == null) {
       return value;
     }
@@ -300,20 +300,6 @@ public class ComputeStep implements TransformStep {
   private Integer getAvroTimeMillis(Object value, LogicalType logicalType) {
     validateLogicalType(value, logicalType, Time.class, LocalTime.class);
     return JstlTypeConverter.INSTANCE.coerceToType(value, Integer.class);
-  }
-
-  private LogicalType getLogicalType(Schema schema) {
-    if (!schema.isUnion()) {
-      return schema.getLogicalType();
-    }
-
-    return schema
-        .getTypes()
-        .stream()
-        .map(Schema::getLogicalType)
-        .filter(Objects::nonNull)
-        .findAny()
-        .orElse(null);
   }
 
   void validateLogicalType(Object value, LogicalType logicalType, Class<?>... expectedClasses) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapter.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.pulsar.functions.transforms.jstl;
 
 import com.datastax.oss.pulsar.functions.transforms.TransformContext;
+import com.datastax.oss.pulsar.functions.transforms.util.AvroUtil;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -135,7 +136,8 @@ public class JstlTransformContextAdapter {
       Object value = null;
       if (genericRecord.hasField(key)) {
         value = genericRecord.get(key);
-        LogicalType logicalType = genericRecord.getSchema().getField(key).schema().getLogicalType();
+        LogicalType logicalType =
+            AvroUtil.getLogicalType(genericRecord.getSchema().getField(key).schema());
         if (LogicalTypes.date().equals(logicalType)) {
           return LocalDate.ofEpochDay((int) value);
         } else if (LogicalTypes.timestampMillis().equals(logicalType)) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/util/AvroUtil.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/util/AvroUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.util;
+
+import java.util.Objects;
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+
+public class AvroUtil {
+
+  /**
+   * Returns the logical type of the schema. If the schema is a union, it will return the logical
+   * type of any of the union types.
+   */
+  public static LogicalType getLogicalType(Schema schema) {
+    if (!schema.isUnion()) {
+      return schema.getLogicalType();
+    }
+
+    return schema
+        .getTypes()
+        .stream()
+        .map(Schema::getLogicalType)
+        .filter(Objects::nonNull)
+        .findAny()
+        .orElse(null);
+  }
+}

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/util/AvroUtilTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/util/AvroUtilTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.pulsar.functions.transforms.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.testng.annotations.Test;
+
+public class AvroUtilTest {
+  private static final MyLogicalType MY_LOGICAL_TYPE = new MyLogicalType();
+
+  @Test
+  public void testGetLogicalType() {
+    // given
+    org.apache.avro.Schema myLogicalTypeSchema =
+        MY_LOGICAL_TYPE.addToSchema(
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN));
+
+    // when
+    LogicalType logicalType = AvroUtil.getLogicalType(myLogicalTypeSchema);
+
+    // then
+    assertNotNull(logicalType);
+    assertEquals("my-logical-type", logicalType.getName());
+  }
+
+  @Test
+  public void testGetLogicalTypeUnion() {
+    // given
+    org.apache.avro.Schema myLogicalTypeSchema =
+        MY_LOGICAL_TYPE.addToSchema(
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN));
+    org.apache.avro.Schema unionSchema =
+        SchemaBuilder.unionOf().nullType().and().type(myLogicalTypeSchema).endUnion();
+
+    // when
+    LogicalType logicalType = AvroUtil.getLogicalType(unionSchema);
+
+    // then
+    assertNotNull(logicalType);
+    assertEquals("my-logical-type", logicalType.getName());
+  }
+
+  public static class MyLogicalType extends LogicalType {
+    MyLogicalType() {
+      super("my-logical-type");
+    }
+
+    @Override
+    public void validate(Schema schema) {
+      super.validate(schema);
+      if (schema.getType() != Schema.Type.BOOLEAN) {
+        throw new IllegalArgumentException(
+            "Logical type 'my-logical-type' should be stored as a boolean");
+      }
+    }
+  }
+}

--- a/tests/src/test/java/com/datastax/oss/pulsar/functions/transforms/tests/util/NativeSchemaWrapper.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/functions/transforms/tests/util/NativeSchemaWrapper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.tests.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Optional;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+public class NativeSchemaWrapper
+    implements org.apache.pulsar.client.api.Schema<org.apache.avro.generic.GenericRecord> {
+  private final SchemaInfo pulsarSchemaInfo;
+  private final org.apache.avro.Schema nativeSchema;
+
+  private final SchemaType pulsarSchemaType;
+
+  private final SpecificDatumWriter datumWriter;
+
+  public NativeSchemaWrapper(org.apache.avro.Schema nativeSchema, SchemaType pulsarSchemaType) {
+    this.nativeSchema = nativeSchema;
+    this.pulsarSchemaType = pulsarSchemaType;
+    this.pulsarSchemaInfo =
+        SchemaInfoImpl.builder()
+            .schema(nativeSchema.toString(false).getBytes(StandardCharsets.UTF_8))
+            .properties(new HashMap<>())
+            .type(pulsarSchemaType)
+            .name(nativeSchema.getName())
+            .build();
+    this.datumWriter = new SpecificDatumWriter<>(this.nativeSchema);
+  }
+
+  @Override
+  public byte[] encode(org.apache.avro.generic.GenericRecord record) {
+    try {
+      SpecificDatumWriter<org.apache.avro.generic.GenericRecord> datumWriter =
+          new SpecificDatumWriter<>(nativeSchema);
+      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+      BinaryEncoder binaryEncoder = new EncoderFactory().binaryEncoder(byteArrayOutputStream, null);
+      datumWriter.write(record, binaryEncoder);
+      binaryEncoder.flush();
+      return byteArrayOutputStream.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public SchemaInfo getSchemaInfo() {
+    return pulsarSchemaInfo;
+  }
+
+  @Override
+  public NativeSchemaWrapper clone() {
+    return new NativeSchemaWrapper(nativeSchema, pulsarSchemaType);
+  }
+
+  @Override
+  public void validate(byte[] message) {
+    // nothing to do
+  }
+
+  @Override
+  public boolean supportSchemaVersioning() {
+    return true;
+  }
+
+  @Override
+  public void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {}
+
+  @Override
+  public GenericRecord decode(byte[] bytes) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean requireFetchingSchemaInfo() {
+    return true;
+  }
+
+  @Override
+  public void configureSchemaInfo(String topic, String componentName, SchemaInfo schemaInfo) {}
+
+  @Override
+  public Optional<Object> getNativeSchema() {
+    return Optional.of(nativeSchema);
+  }
+}


### PR DESCRIPTION
Fixes #66 

This patch fixes how the JstlTransformContextAdapter fetches AVRO logical type info. Before, it was working only if the logical type was inside a non-union schema. In general, Avro nullable types (like those produced by the compute step) would have a union schema like the following (for those, logical types won't be found by simply accessing `schema().getLogicalType()` and the nested types should be consulted):
```
{
        "name": "...",
        "type": [
          "null",
          {
            "type": "...",
            "logicalType": "..."
          }
        ],
        "default": null
      }
```