### PR TITLE
Use a template filled with the message fields and metadata for the embeddings

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ChatCompletionsStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ChatCompletionsStep.java
@@ -57,21 +57,7 @@ public class ChatCompletionsStep implements TransformStep {
 
   @Override
   public void process(TransformContext transformContext) throws Exception {
-    JsonRecord jsonRecord = new JsonRecord();
-    if (transformContext.getKeySchema() != null) {
-      jsonRecord.setKey(
-          toJsonSerializable(transformContext.getKeySchema(), transformContext.getKeyObject()));
-    } else {
-      jsonRecord.setKey(transformContext.getKey());
-    }
-    jsonRecord.setValue(
-        toJsonSerializable(transformContext.getValueSchema(), transformContext.getValueObject()));
-    jsonRecord.setDestinationTopic(transformContext.getOutputTopic());
-
-    jsonRecord.setProperties(transformContext.getOutputProperties());
-    Record<?> currentRecord = transformContext.getContext().getCurrentRecord();
-    currentRecord.getEventTime().ifPresent(jsonRecord::setEventTime);
-    currentRecord.getTopicName().ifPresent(jsonRecord::setTopicName);
+    JsonRecord jsonRecord = transformContext.toJsonRecord();
 
     List<ChatMessage> messages =
         config

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/QueryStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/QueryStep.java
@@ -43,9 +43,9 @@ import org.apache.pulsar.common.schema.SchemaType;
 public class QueryStep implements TransformStep {
 
   @Builder.Default private final List<String> fields = new ArrayList<>();
-  @Builder.Default private final String outputFieldName;
-  @Builder.Default private final String query;
-  @Builder.Default private final QueryStepDataSource dataSource;
+  private final String outputFieldName;
+  private final String query;
+  private final QueryStepDataSource dataSource;
   private final Map<Schema, Schema> avroValueSchemaCache = new ConcurrentHashMap<>();
 
   @Override

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -383,11 +383,10 @@ public class TransformFunction
   }
 
   private TransformStep newComputeAIEmbeddings(ComputeAIEmbeddingsConfig config) {
-    return ComputeAIEmbeddingsStep.builder()
-        .embeddingsService(new OpenAIEmbeddingsService(openAIClient, config.getModel()))
-        .embeddingsFieldName(config.getEmbeddingsFieldName())
-        .fields(config.getFields())
-        .build();
+    return new ComputeAIEmbeddingsStep(
+        config.getText(),
+        config.getEmbeddingsFieldName(),
+        new OpenAIEmbeddingsService(openAIClient, config.getModel()));
   }
 
   private static UnwrapKeyValueStep newUnwrapKeyValueFunction(UnwrapKeyValueConfig config) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/ComputeAIEmbeddingsConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/ComputeAIEmbeddingsConfig.java
@@ -21,11 +21,11 @@ import lombok.Getter;
 
 @Getter
 public class ComputeAIEmbeddingsConfig extends StepConfig {
-  @JsonProperty(value = "model", required = true)
+  @JsonProperty(required = true)
   private String model;
 
-  @JsonProperty(value = "fields", required = true)
-  private List<String> fields;
+  @JsonProperty(required = true)
+  private String text;
 
   @JsonProperty(value = "embeddings-field", required = true)
   private String embeddingsFieldName;

--- a/pulsar-transformations/src/main/resources/config-schema.yaml
+++ b/pulsar-transformations/src/main/resources/config-schema.yaml
@@ -244,18 +244,15 @@ components:
               type:
                 - string
               description: The record field where to inject the computed embeddings value. If the field already exists, it will be used. Note that the field must be a representation of a double's array.
-            fields:
-              type: array
-              minItems: 1
-              items:
-                type:
-                  - string
-              description: The record fields to compute embeddings for. The fields value will be concatened.
+            text:
+              type:
+                - string
+              description: The text to use to compute the embeddings. Fields and metadata from the message can be used using mustache placeholders.
           required:
             - type
             - model
             - embeddings-field
-            - fields
+            - text
         - "$ref": "#/components/schemas/Part"
     AIChatCompletions:
       allOf:

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ComputeAIEmbeddingsTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ComputeAIEmbeddingsTest.java
@@ -60,11 +60,7 @@ public class ComputeAIEmbeddingsTest {
     final List<Double> expectedEmbeddings = Arrays.asList(1.0d, 2.0d, 3.0d);
     mockService.setEmbeddingsForText("Jane The Princess ", expectedEmbeddings);
     ComputeAIEmbeddingsStep step =
-        ComputeAIEmbeddingsStep.builder()
-            .embeddingsFieldName("newField")
-            .embeddingsService(mockService)
-            .fields(List.of("firstName", "lastName"))
-            .build();
+        new ComputeAIEmbeddingsStep("{{ value.firstName }} {{ value.lastName }}", "newField", mockService);
 
     Record<?> outputRecord = Utils.process(record, step);
     GenericData.Record read =
@@ -81,11 +77,7 @@ public class ComputeAIEmbeddingsTest {
     final List<Double> expectedEmbeddings = Arrays.asList(1.0d, 2.0d, 3.0d);
     mockService.setEmbeddingsForText("key1", expectedEmbeddings);
     ComputeAIEmbeddingsStep step =
-        ComputeAIEmbeddingsStep.builder()
-            .embeddingsFieldName("newField")
-            .embeddingsService(mockService)
-            .fields(List.of("keyField1"))
-            .build();
+        new ComputeAIEmbeddingsStep("{{ key.keyField1 }}", "newField", mockService);
 
     Record<?> outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
@@ -118,11 +110,7 @@ public class ComputeAIEmbeddingsTest {
     final List<Double> expectedEmbeddings = Arrays.asList(1.0d, 2.0d, 3.0d);
     mockService.setEmbeddingsForText("Jane The Princess ", expectedEmbeddings);
     ComputeAIEmbeddingsStep step =
-        ComputeAIEmbeddingsStep.builder()
-            .embeddingsFieldName("newField")
-            .embeddingsService(mockService)
-            .fields(List.of("firstName", "lastName"))
-            .build();
+        new ComputeAIEmbeddingsStep("{{ value.firstName }} {{ value.lastName }}", "newField", mockService);
 
     Record<?> outputRecord = Utils.process(record, step);
 

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
@@ -136,7 +136,7 @@ public class TransformFunctionTest {
       {"{'steps': [], 'openai': {'access-key': 'qwerty', 'url': 'some-url', 'provider': 'azure'}}"},
       {"{'steps': [], 'openai': {'access-key': 'qwerty'}}"},
       {
-        "{'steps': [{'type': 'compute-ai-embeddings', 'fields': ['field1', 'field2'], 'embeddings-field': 'emb', 'model': 'the-new-model'}]}"
+        "{'steps': [{'type': 'compute-ai-embeddings', 'text': '{{ value }}', 'embeddings-field': 'emb', 'model': 'the-new-model'}]}"
       },
       {
         "{"
@@ -257,10 +257,10 @@ public class TransformFunctionTest {
       {"{'steps': [], 'openai': {'url': 'some-url'}}"},
       {"{'steps': [], 'openai': {'provider': 'invalid'}}"},
       {
-        "{'steps': [{'type': 'compute-ai-embeddings', 'fields': ['field1', 'field2'], 'embeddings-field': 'emb'}]}"
+        "{'steps': [{'type': 'compute-ai-embeddings', 'text': '{{ value }}', 'embeddings-field': 'emb'}]}"
       },
       {
-        "{'steps': [{'type': 'compute-ai-embeddings', 'fields': ['field1', 'field2'], 'model': 'the-new-model'}]}"
+        "{'steps': [{'type': 'compute-ai-embeddings', 'text': '{{ value }}', 'model': 'the-new-model'}]}"
       },
       {
         "{'steps': [{'type': 'compute-ai-embeddings', 'embeddings-field': 'emb', 'model': 'the-new-model'}]}"


### PR DESCRIPTION
You can have the same as before by doing
```json
{"steps": [{"type": "compute-ai-embeddings", "text": "{{ value.valueField1 }} {{ value.valueField2 }}", "embeddings-field": "emb", "model": "gpt-3.5-turbo"}]}
```