### PR TITLE
Use key instead of messageKey in EL

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,9 +306,8 @@ When a function returns a timestamp, its type is `INSTANT`.
 
 Each step accept an optional `when` configuration that is evaluated at step execution time against current record (i.e. the as seen by
 the current step in the transformation pipeline). The `when` condition supports the [Expression Language](#expression-language) syntax. It provides access to the record attributes as follows:
-* `key`: the key portion of the record in a KeyValue schema. 
+* `key`: the message key or the key portion of the record in a KeyValue schema.
 * `value`: the value portion of the record in a KeyValue schema, or the message payload itself.
-* `messageKey`: the optional key messages are tagged with (aka. Partition Key).
 * `topicName`: the optional name of the topic which the record originated from (aka. Input Topic).
 * `destinationTopic`: the name of the topic on which the transformed record will be sent (aka. Output Topic).
 * `eventTime`: the optional timestamp attached to the record from its source. For example, the original timestamp attached to the pulsar message.
@@ -350,11 +349,11 @@ You can use the `.` operator to access top level or nested properties on a schem
 * User defined k/v: `{"prop1": "p1", "prop2": "p2"}`
 * Payload (String): `Hello world!`
 
-| when                                               | Evaluates to |
-|----------------------------------------------------|--------------|
-| `"messageKey == 'key1' or topicName == 'topic1' "` | True         | 
-| `"value == 'Hello world!'"`                        | True         |
-| `"properties.prop1 == 'p2'"`                       | False        |
+| when                                        | Evaluates to |
+|---------------------------------------------|--------------|
+| `"key == 'key1' or topicName == 'topic1' "` | True         |
+| `"value == 'Hello world!'"`                 | True         |
+| `"properties.prop1 == 'p2'"`                | False        |
 
 ## Deployment
 

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapter.java
@@ -103,9 +103,13 @@ public class JstlTransformContextAdapter {
    *     object, or the primitive type itself.
    */
   public Object getKey() {
-    return this.transformContext.getKeyObject() instanceof GenericRecord
+    Object keyObject = this.transformContext.getKeyObject();
+    if (keyObject == null) {
+      return transformContext.getKey();
+    }
+    return keyObject instanceof GenericRecord
         ? lazyKey
-        : this.transformContext.getKeyObject();
+        : keyObject;
   }
 
   /**

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapterTest.java
@@ -109,7 +109,7 @@ public class JstlTransformContextAdapterTest {
 
     // then
     assertEquals(adapter.getHeader().get("messageKey"), "header-key");
-    assertNull(adapter.getKey());
+    assertEquals(adapter.getKey(), "header-key");
 
     assertEquals(adapter.getValue(), "test-message");
     assertEquals(adapter.getValue(), "test-message");
@@ -136,7 +136,7 @@ public class JstlTransformContextAdapterTest {
 
     // then
     assertEquals(adapter.getHeader().get("messageKey"), "header-key");
-    assertNull(adapter.getKey());
+    assertEquals(adapter.getKey(), "header-key");
     assertTrue(adapter.getValue() instanceof Map);
     Map<String, Object> valueMap = (Map<String, Object>) adapter.getValue();
     assertNestedRecord(valueMap);

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/predicate/JstlPredicateTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/predicate/JstlPredicateTest.java
@@ -113,6 +113,7 @@ public class JstlPredicateTest {
       // match
       {"value=='test-message'", primitiveStringContext, true},
       {"messageKey=='header-key'", primitiveStringContext, true},
+      {"key=='header-key'", primitiveStringContext, true},
       {"value==33", primitiveIntContext, true},
       {"value eq 33", primitiveIntContext, true},
       {"value eq 32 + 1", primitiveIntContext, true},
@@ -123,21 +124,20 @@ public class JstlPredicateTest {
       {"value mod 10 == 3", primitiveIntContext, true},
       {"value>32", primitiveIntContext, true},
       {"value gt 32", primitiveIntContext, true},
-      {"value<=33 && messageKey=='header-key'", primitiveIntContext, true},
+      {"value<=33 && key=='header-key'", primitiveIntContext, true},
       {"key=='key' && value==42", primitiveKVContext, true},
       {"key=='key' and value==42", primitiveKVContext, true},
       {"key=='key1' || value==42", primitiveKVContext, true},
       {"key=='key1' or value==42", primitiveKVContext, true},
       {"key=='key' && value==42", primitiveKVContext, true},
-      {"key=='key' && messageKey=='header-key'", primitiveKVContext, true},
       // no-match
       {"value=='test-message-'", primitiveStringContext, false},
-      {"messageKey!='header-key'", primitiveStringContext, false},
-      {"messageKey ne 'header-key'", primitiveStringContext, false},
+      {"key!='header-key'", primitiveStringContext, false},
+      {"key ne 'header-key'", primitiveStringContext, false},
       {"value==34", primitiveIntContext, false},
       {"value>33", primitiveIntContext, false},
-      {"value<=20 && messageKey=='test-key'", primitiveIntContext, false},
-      {"value le 20 && messageKey=='test-key'", primitiveIntContext, false},
+      {"value<=20 && key=='test-key'", primitiveIntContext, false},
+      {"value le 20 && key=='test-key'", primitiveIntContext, false},
     };
   }
 


### PR DESCRIPTION
* messageKey is still possible for backward compatibility
* if the shema is KeyValue, key refers to the key part of the KV. Otherwise key refers to the message key in metadata.