### PR TITLE
[chat-completion]: add a field with debug information about the prompt and the api call

### DIFF
--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ChatCompletionsStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/ChatCompletionsStep.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -86,6 +87,18 @@ public class ChatCompletionsStep implements TransformStep {
     // TODO: At the moment, we only support outputing the value with STRING schema.
 
     String fieldName = config.getFieldName();
+    storeField(transformContext, content, fieldName);
+
+    String logField = config.getLogField();
+    if (logField != null && !logField.isEmpty()) {
+      Map<String, Object> logMap = new HashMap<>();
+      logMap.put("model", config.getModel());
+      logMap.put("options", chatCompletionsOptions);
+      storeField(transformContext, TransformContext.toJson(logMap), logField);
+    }
+  }
+
+  private void storeField(TransformContext transformContext, String content, String fieldName) {
     if (fieldName == null || fieldName.equals("value")) {
       transformContext.setValueSchema(org.apache.pulsar.client.api.Schema.STRING);
       transformContext.setValueObject(content);

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformContext.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformContext.java
@@ -20,6 +20,7 @@ import static org.apache.pulsar.common.schema.SchemaType.AVRO;
 import com.datastax.oss.pulsar.functions.transforms.model.JsonRecord;
 import com.datastax.oss.pulsar.functions.transforms.util.AvroUtil;
 import com.datastax.oss.pulsar.functions.transforms.util.JsonConverter;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
@@ -241,5 +242,9 @@ public class TransformContext {
         throw new UnsupportedOperationException(
             "Unsupported schemaType " + schema.getSchemaInfo().getType());
     }
+  }
+
+  public static String toJson(Object object) throws JsonProcessingException {
+    return OBJECT_MAPPER.writeValueAsString(object);
   }
 }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapter.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapter.java
@@ -107,9 +107,7 @@ public class JstlTransformContextAdapter {
     if (keyObject == null) {
       return transformContext.getKey();
     }
-    return keyObject instanceof GenericRecord
-        ? lazyKey
-        : keyObject;
+    return keyObject instanceof GenericRecord ? lazyKey : keyObject;
   }
 
   /**

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/ChatCompletionsConfig.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/config/ChatCompletionsConfig.java
@@ -33,6 +33,9 @@ public class ChatCompletionsConfig extends StepConfig {
   @JsonProperty(value = "completion-field")
   private String fieldName;
 
+  @JsonProperty(value = "log-field")
+  private String logField;
+
   @JsonProperty(value = "max-tokens")
   private Integer maxTokens;
 


### PR DESCRIPTION
In the char-completion step it would be great to have a way to store the actual prompt that we sent to OpenAI.

Summary:
- add a new "log-field" option to the chat-completion step that contains useful information about the API call that have been made
- this is useful because this way you can see the actual prompt (as result of applying the template)