### PR TITLE
[compute-ai-embeddings] Some enhancements to HF configuration

### DIFF
--- a/pulsar-ai-tools/src/main/resources/config-schema.yaml
+++ b/pulsar-ai-tools/src/main/resources/config-schema.yaml
@@ -244,6 +244,14 @@ components:
               type:
                 - string
               description: The record field where to inject the computed embeddings value. If the field already exists, it will be used. Note that the field must be a representation of a double's array.
+            compute-service:
+              type:
+                - string
+              description: Service type to use to compute the embeddings. Currently only OpenAI and HuggingFace are supported.
+            model-url:
+              type:
+                - string
+              description: URL of the Hugging Face Model to use. Only used if `compute-service` is set to `huggingface`.
             text:
               type:
                 - string

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -402,7 +402,11 @@ public class TransformFunction
   private TransformStep newComputeAIEmbeddings(ComputeAIEmbeddingsConfig config) {
     String targetSvc = config.getService();
     if (Strings.isNullOrEmpty(targetSvc)) {
+
       targetSvc = ComputeAIEmbeddingsConfig.SupportedServices.OPENAI.name();
+      if (openAIClient == null && huggingConfig != null) {
+        targetSvc = ComputeAIEmbeddingsConfig.SupportedServices.HUGGINGFACE.name();
+      }
     }
 
     ComputeAIEmbeddingsConfig.SupportedServices service =
@@ -417,7 +421,6 @@ public class TransformFunction
         Objects.requireNonNull(huggingConfig, "huggingface config is required");
         switch (huggingConfig.getProvider()) {
           case LOCAL:
-            Objects.requireNonNull(config.getModelUrl(), "model URL is required");
             AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.HuggingFaceConfigBuilder builder =
                 AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.builder()
                     .options(config.getOptions())
@@ -434,7 +437,7 @@ public class TransformFunction
             HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.HuggingFaceApiConfigBuilder
                 apiBuilder =
                     HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.builder()
-                        .accesKey(huggingConfig.getAccessKey())
+                        .accessKey(huggingConfig.getAccessKey())
                         .model(config.getModel());
 
             if (!Strings.isNullOrEmpty(huggingConfig.getApiUrl())) {

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -73,6 +73,8 @@ import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
 import org.apache.pulsar.functions.api.Record;
 
+import static com.datastax.oss.pulsar.functions.transforms.embeddings.AbstractHuggingFaceEmbeddingService.DLJ_BASE_URL;
+
 /**
  * <code>TransformFunction</code> is a {@link Function} that provides an easy way to apply a set of
  * usual basic transformations to the data.
@@ -426,9 +428,17 @@ public class TransformFunction
                     .options(config.getOptions())
                     .arguments(config.getArguments())
                     .modelUrl(config.getModelUrl());
+            String modelUrl = config.getModelUrl();
             if (!Strings.isNullOrEmpty(config.getModel())) {
               builder.modelName(config.getModel());
+
+              // automatically build the model URL if not provided
+              if (!Strings.isNullOrEmpty(modelUrl)) {
+                modelUrl = DLJ_BASE_URL + config.getModel();
+                log.info("Automatically computed model URL {}", modelUrl);
+              }
             }
+            builder.modelUrl(modelUrl);
 
             embeddingService = new HuggingFaceEmbeddingService(builder.build());
             break;

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/embeddings/AbstractHuggingFaceEmbeddingService.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/embeddings/AbstractHuggingFaceEmbeddingService.java
@@ -43,7 +43,7 @@ public abstract class AbstractHuggingFaceEmbeddingService<IN, OUT>
    */
   public static final String URL_PREFIXES_SYSTEM_PROP = "ALLOWED_HF_URLS";
 
-  private static final String DLJ_BASE_URL = "djl://ai.djl.huggingface.pytorch/sentence-transformers/";
+  public static final String DLJ_BASE_URL = "djl://ai.djl.huggingface.pytorch";
 
   public static final Set<String> allowedUrlPrefixes = getHuggingFaceAllowedUrlPrefixes();
 
@@ -97,11 +97,7 @@ public abstract class AbstractHuggingFaceEmbeddingService<IN, OUT>
   public AbstractHuggingFaceEmbeddingService(HuggingFaceConfig conf)
       throws IOException, ModelNotFoundException, MalformedModelException, IllegalAccessException {
     Objects.requireNonNull(conf);
-
-    if (conf.modelUrl == null) {
-      conf.modelUrl = DLJ_BASE_URL + conf.modelName;
-      log.info("Automatically computed model URL {}", conf.modelUrl);
-    }
+    Objects.requireNonNull(conf.modelName);
 
     checkIfUrlIsAllowed(conf.modelUrl);
 

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/embeddings/AbstractHuggingFaceEmbeddingService.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/embeddings/AbstractHuggingFaceEmbeddingService.java
@@ -43,6 +43,8 @@ public abstract class AbstractHuggingFaceEmbeddingService<IN, OUT>
    */
   public static final String URL_PREFIXES_SYSTEM_PROP = "ALLOWED_HF_URLS";
 
+  private static final String DLJ_BASE_URL = "djl://ai.djl.huggingface.pytorch/sentence-transformers/";
+
   public static final Set<String> allowedUrlPrefixes = getHuggingFaceAllowedUrlPrefixes();
 
   private static Set<String> getHuggingFaceAllowedUrlPrefixes() {
@@ -51,7 +53,7 @@ public abstract class AbstractHuggingFaceEmbeddingService<IN, OUT>
       prop = System.getProperty(URL_PREFIXES_SYSTEM_PROP);
     }
     if (Strings.isNullOrEmpty(prop)) {
-      prop = "file://";
+      prop = "file://," + DLJ_BASE_URL;
     }
     return Set.of(prop.split(","));
   }
@@ -95,7 +97,11 @@ public abstract class AbstractHuggingFaceEmbeddingService<IN, OUT>
   public AbstractHuggingFaceEmbeddingService(HuggingFaceConfig conf)
       throws IOException, ModelNotFoundException, MalformedModelException, IllegalAccessException {
     Objects.requireNonNull(conf);
-    Objects.requireNonNull(conf.modelUrl);
+
+    if (conf.modelUrl == null) {
+      conf.modelUrl = DLJ_BASE_URL + conf.modelName;
+      log.info("Automatically computed model URL {}", conf.modelUrl);
+    }
 
     checkIfUrlIsAllowed(conf.modelUrl);
 

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/embeddings/HuggingFaceRestEmbeddingService.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/embeddings/HuggingFaceRestEmbeddingService.java
@@ -42,7 +42,7 @@ public class HuggingFaceRestEmbeddingService implements EmbeddingsService {
   @Data
   @Builder
   public static class HuggingFaceApiConfig {
-    public String accesKey;
+    public String accessKey;
     public String model;
 
     @Builder.Default public String hfUrl = HF_URL;
@@ -77,7 +77,7 @@ public class HuggingFaceRestEmbeddingService implements EmbeddingsService {
   public HuggingFaceRestEmbeddingService(HuggingFaceApiConfig conf) throws MalformedURLException {
     this.conf = conf;
     this.model = conf.model;
-    this.token = conf.accesKey;
+    this.token = conf.accessKey;
     this.modelUrl = new URL(conf.hfUrl + model);
 
     this.httpClient = HttpClient.newHttpClient();

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/embeddings/HuggingFaceRestEmbeddingServiceTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/embeddings/HuggingFaceRestEmbeddingServiceTest.java
@@ -25,7 +25,7 @@ public abstract class HuggingFaceRestEmbeddingServiceTest extends TestCase {
   public void testMain() throws Exception {
     HuggingFaceRestEmbeddingService.HuggingFaceApiConfig conf =
         HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.builder()
-            .accesKey(System.getenv("HF_API_KEY"))
+            .accessKey(System.getenv("HF_API_KEY"))
             .model("sentence-transformers/all-MiniLM-L6-v2")
             .options(Map.of("wait_for_model", "true"))
             .build();


### PR DESCRIPTION
This patch introduces some small enhancements to make the life of HF users easier:
1) Automatically detect HF service (if you configured HF and not OpenAI then it is clear that you want HF)
2) Automatically compose HF URLs when working on "local" mode
3) Allow Only some djl:// urls but default, limiting the models to sentence transformers

With this patch this is how you configure compute-ai-embeddings with HF.

API MODE:

```

{
  "datasource": {
     ...  
},
  "huggingface": {
    "provider": "api",
    "access-key": "xxxxxxxx"
    },
  "steps": [
    {
      "type": "compute-ai-embeddings",
      "model": "sentence-transformers/all-MiniLM-L6-v2",
      "embeddings-field": "value.embeddings"
      "text": "{{ value.name }} {{ value.description }}"
    },
    {
      "type": "query",
      "query": "SELECT * FROM vsearch.products ORDER BY item_vector ANN OF ? LIMIT 1;",
      "output-field": "value.results",
      "fields": ["value.embeddings"]
    }
  ]
}
```


LOCAL MODE:

```

{
  "datasource": {
     ...  
},
  "huggingface": {
    "provider": "local"
    },
  "steps": [
    {
      "type": "compute-ai-embeddings",
      "model": "sentence-transformers/all-MiniLM-L6-v2",
      "embeddings-field": "value.embeddings",
      "text": "{{ value.name }} {{ value.description }}"
    },
    {
      "type": "query",
      "query": "SELECT * FROM vsearch.products ORDER BY item_vector ANN OF ? LIMIT 1;",
      "output-field": "value.results",
      "fields": ["value.embeddings"]
    }
  ]
}
```
