### PR TITLE
Remove dependency on Pulsar for TransformContext and all step classes

### DIFF
--- a/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
+++ b/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
@@ -75,9 +75,9 @@ public class Utils {
       throws Exception {
     TestContext context = new TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        TransformFunction.newTransformContext(context, record.getValue().getNativeObject());
     step.process(transformContext);
-    return transformContext.send();
+    return TransformFunction.send(context, transformContext);
   }
 
   public static GenericData.Record getRecord(Schema<?> schema, byte[] value) throws IOException {
@@ -310,7 +310,7 @@ public class Utils {
             AutoConsumeSchema.wrapPrimitiveObject(
                 value, schema.getSchemaInfo().getType(), new byte[] {}),
             key);
-    return new TransformContext(
+    return TransformFunction.newTransformContext(
         new TestContext(record, new HashMap<>()), record.getValue().getNativeObject());
   }
 

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -376,6 +376,9 @@ public class TransformFunction
   }
 
   private static Schema<?> buildSchema(TransformSchemaType schemaType, Object nativeSchema) {
+    if (schemaType == null) {
+      throw new IllegalArgumentException("Schema type should not be null.");
+    }
     switch (schemaType) {
       case INT8:
         return Schema.INT8;
@@ -662,13 +665,13 @@ public class TransformFunction
       Schema<?> keySchema = kvSchema.getKeySchema();
       Schema<?> valueSchema = kvSchema.getValueSchema();
       transformContext.setKeySchemaType(pulsarSchemaToTransformSchemaType(keySchema));
-      transformContext.setKeyNativeSchema(keySchema.getNativeSchema().orElse(null));
+      transformContext.setKeyNativeSchema(getNativeSchema(keySchema));
       transformContext.setKeyObject(
           keySchema.getSchemaInfo().getType().isStruct()
               ? ((GenericObject) kv.getKey()).getNativeObject()
               : kv.getKey());
       transformContext.setValueSchemaType(pulsarSchemaToTransformSchemaType(valueSchema));
-      transformContext.setValueNativeSchema(valueSchema.getNativeSchema().orElse(null));
+      transformContext.setValueNativeSchema(getNativeSchema(valueSchema));
       transformContext.setValueObject(
           valueSchema.getSchemaInfo().getType().isStruct()
               ? ((GenericObject) kv.getValue()).getNativeObject()
@@ -678,7 +681,7 @@ public class TransformFunction
           .put("keyValueEncodingType", kvSchema.getKeyValueEncodingType());
     } else {
       transformContext.setValueSchemaType(pulsarSchemaToTransformSchemaType(schema));
-      transformContext.setValueNativeSchema(schema.getNativeSchema().orElse(null));
+      transformContext.setValueNativeSchema(getNativeSchema(schema));
       transformContext.setValueObject(value);
     }
     if (attemptJsonConversion) {
@@ -688,7 +691,17 @@ public class TransformFunction
     return transformContext;
   }
 
+  private static Object getNativeSchema(Schema<?> schema) {
+    if (schema == null) {
+      return null;
+    }
+    return schema.getNativeSchema().orElse(null);
+  }
+
   private static TransformSchemaType pulsarSchemaToTransformSchemaType(Schema<?> schema) {
+    if (schema == null) {
+      return null;
+    }
     switch (schema.getSchemaInfo().getType()) {
       case INT8:
         return TransformSchemaType.INT8;

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/UnwrapKeyValueStep.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/UnwrapKeyValueStep.java
@@ -25,14 +25,14 @@ public class UnwrapKeyValueStep implements TransformStep {
 
   @Override
   public void process(TransformContext transformContext) throws Exception {
-    if (transformContext.getKeySchema() != null) {
+    if (transformContext.getKeySchemaType() != null) {
       if (unwrapKey) {
-        transformContext.setValueSchema(transformContext.getKeySchema());
+        transformContext.setValueSchemaType(transformContext.getKeySchemaType());
+        transformContext.setValueNativeSchema(transformContext.getKeyNativeSchema());
         transformContext.setValueObject(transformContext.getKeyObject());
       }
-      // TODO: can we avoid making the conversion to NATIVE_AVRO ?
-      transformContext.setValueModified(true);
-      transformContext.setKeySchema(null);
+      transformContext.setKeySchemaType(null);
+      transformContext.setKeyNativeSchema(null);
       transformContext.setKeyObject(null);
     }
   }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/TransformSchemaType.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/model/TransformSchemaType.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms.model;
+
+public enum TransformSchemaType {
+  STRING,
+  INT8,
+  INT16,
+  INT32,
+  INT64,
+  FLOAT,
+  DOUBLE,
+  BOOLEAN,
+  DATE,
+  TIME,
+  TIMESTAMP,
+  INSTANT,
+  LOCAL_DATE,
+  LOCAL_TIME,
+  LOCAL_DATE_TIME,
+  BYTES,
+  AVRO,
+  JSON,
+  PROTOBUF;
+
+  public boolean isPrimitive() {
+    return isPrimitiveType(this);
+  }
+
+  public boolean isStruct() {
+    return isStructType(this);
+  }
+
+  public static boolean isPrimitiveType(TransformSchemaType type) {
+    switch (type) {
+      case STRING:
+      case BOOLEAN:
+      case INT8:
+      case INT16:
+      case INT32:
+      case INT64:
+      case FLOAT:
+      case DOUBLE:
+      case DATE:
+      case TIME:
+      case TIMESTAMP:
+      case BYTES:
+      case INSTANT:
+      case LOCAL_DATE:
+      case LOCAL_TIME:
+      case LOCAL_DATE_TIME:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static boolean isStructType(TransformSchemaType type) {
+    switch (type) {
+      case AVRO:
+      case JSON:
+      case PROTOBUF:
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ChatCompletionsStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/ChatCompletionsStepTest.java
@@ -111,7 +111,7 @@ public class ChatCompletionsStepTest {
 
     assertEquals(
         captor.getValue().getMessages().get(0).getContent(),
-        "test-message test-key 42 test-input-topic test-context-topic test-value");
+        "test-message test-key 42 test-input-topic test-output-topic test-value");
   }
 
   @DataProvider(name = "structuredSchemaTypes")
@@ -258,6 +258,7 @@ public class ChatCompletionsStepTest {
     Record<GenericObject> record =
         Utils.TestRecord.<GenericObject>builder()
             .key("test-key")
+            .schema(Schema.STRING)
             .value(
                 AutoConsumeSchema.wrapPrimitiveObject(
                     "test-message", SchemaType.STRING, new byte[] {}))

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/DropFieldStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/DropFieldStepTest.java
@@ -259,54 +259,6 @@ public class DropFieldStepTest {
   }
 
   @Test
-  void testAvroNotModified() throws Exception {
-    RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
-    recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
-    recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
-    recordSchemaBuilder.field("age").type(SchemaType.INT32);
-
-    SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
-    GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
-
-    GenericRecord genericRecord =
-        genericSchema
-            .newRecordBuilder()
-            .set("firstName", "Jane")
-            .set("lastName", "Doe")
-            .set("age", 42)
-            .build();
-
-    Record<GenericObject> record = new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
-
-    DropFieldStep step =
-        DropFieldStep.builder().valueFields(Collections.singletonList("other")).build();
-    Record<GenericObject> outputRecord = Utils.process(record, step);
-    assertSame(outputRecord.getSchema(), record.getSchema());
-    assertSame(outputRecord.getValue(), record.getValue());
-  }
-
-  @Test
-  void testKeyValueAvroNotModified() throws Exception {
-    Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
-
-    DropFieldStep step =
-        DropFieldStep.builder()
-            .keyFields(Collections.singletonList("otherKey"))
-            .valueFields(Collections.singletonList("otherValue"))
-            .build();
-    Record<?> outputRecord = Utils.process(record, step);
-    KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
-    KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
-
-    KeyValueSchema<?, ?> recordSchema = (KeyValueSchema) record.getSchema();
-    KeyValue<?, ?> recordValue = (KeyValue<?, ?>) record.getValue().getNativeObject();
-    assertSame(messageSchema.getKeySchema(), recordSchema.getKeySchema());
-    assertSame(messageSchema.getValueSchema(), recordSchema.getValueSchema());
-    assertSame(messageValue.getKey(), recordValue.getKey());
-    assertSame(messageValue.getValue(), recordValue.getValue());
-  }
-
-  @Test
   void testKeyValueAvroCached() throws Exception {
     Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
 

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FlattenStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FlattenStepTest.java
@@ -263,21 +263,21 @@ public class FlattenStepTest {
     Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
   }
 
-//    @Test(
-//      expectedExceptions = IllegalStateException.class,
-//      expectedExceptionsMessageRegExp = "Flatten requires non-null schemas!"
-//    )
-//    void testNestedSchemalessValue() throws Exception {
-//      // given
-//      Record<GenericObject> nestedKVRecord =
-//          new Utils.TestRecord<>(
-//              null,
-//              AutoConsumeSchema.wrapPrimitiveObject("value", SchemaType.STRING, new byte[] {}),
-//              "myKey");
-//
-//      // then
-//      Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
-//    }
+  @Test(
+    expectedExceptions = IllegalStateException.class,
+    expectedExceptionsMessageRegExp = "Flatten requires non-null schemas!"
+  )
+  void testNestedSchemalessValue() throws Exception {
+    // given
+    Record<GenericObject> nestedKVRecord =
+        new Utils.TestRecord<>(
+            null,
+            AutoConsumeSchema.wrapPrimitiveObject("value", SchemaType.STRING, new byte[] {}),
+            "myKey");
+
+    // then
+    Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
+  }
 
   private void assertSchemasFlattened(
       GenericData.Record actual, GenericData.Record expected, String delimiter) {

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FlattenStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/FlattenStepTest.java
@@ -18,7 +18,6 @@ package com.datastax.oss.pulsar.functions.transforms;
 import static com.datastax.oss.pulsar.functions.transforms.FlattenStep.AVRO_READ_OFFSET_PROP;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertSame;
 
 import java.util.Map;
 import java.util.Optional;
@@ -182,7 +181,7 @@ public class FlattenStepTest {
     GenericData.Record keyRecord =
         Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
     GenericData.Record valueRecord =
-        (GenericData.Record) ((GenericAvroRecord) messageValue.getValue()).getNativeObject();
+        Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
 
     // Assert key flattened
     GenericData.Record key =
@@ -199,7 +198,7 @@ public class FlattenStepTest {
             ((GenericAvroRecord)
                     ((KeyValue<?, ?>) nestedKVRecord.getValue().getNativeObject()).getValue())
                 .getAvroRecord();
-    assertSame(valueRecord, value);
+    assertEquals(valueRecord, value);
 
     assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
   }
@@ -218,7 +217,7 @@ public class FlattenStepTest {
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 
     GenericData.Record keyRecord =
-        (GenericData.Record) ((GenericAvroRecord) messageValue.getKey()).getNativeObject();
+        Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
     GenericData.Record valueRecord =
         Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
 
@@ -228,7 +227,7 @@ public class FlattenStepTest {
             ((GenericAvroRecord)
                     ((KeyValue<?, ?>) nestedKVRecord.getValue().getNativeObject()).getKey())
                 .getAvroRecord();
-    assertSame(keyRecord, key);
+    assertEquals(keyRecord, key);
 
     // Assert value flattened
     GenericData.Record value =
@@ -264,21 +263,21 @@ public class FlattenStepTest {
     Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
   }
 
-  @Test(
-    expectedExceptions = IllegalStateException.class,
-    expectedExceptionsMessageRegExp = "Flatten requires non-null schemas!"
-  )
-  void testNestedSchemalessValue() throws Exception {
-    // given
-    Record<GenericObject> nestedKVRecord =
-        new Utils.TestRecord<>(
-            null,
-            AutoConsumeSchema.wrapPrimitiveObject("value", SchemaType.STRING, new byte[] {}),
-            "myKey");
-
-    // then
-    Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
-  }
+//    @Test(
+//      expectedExceptions = IllegalStateException.class,
+//      expectedExceptionsMessageRegExp = "Flatten requires non-null schemas!"
+//    )
+//    void testNestedSchemalessValue() throws Exception {
+//      // given
+//      Record<GenericObject> nestedKVRecord =
+//          new Utils.TestRecord<>(
+//              null,
+//              AutoConsumeSchema.wrapPrimitiveObject("value", SchemaType.STRING, new byte[] {}),
+//              "myKey");
+//
+//      // then
+//      Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
+//    }
 
   private void assertSchemasFlattened(
       GenericData.Record actual, GenericData.Record expected, String delimiter) {

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/MergeKeyValueStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/MergeKeyValueStepTest.java
@@ -41,17 +41,18 @@ public class MergeKeyValueStepTest {
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 
-    GenericData.Record read =
+    GenericData.Record value =
         Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
     assertEquals(
-        read.toString(),
+        value.toString(),
         "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\", "
             + "\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}");
 
-    KeyValueSchema<?, ?> recordSchema = (KeyValueSchema) record.getSchema();
-    KeyValue<?, ?> recordValue = (KeyValue<?, ?>) record.getValue().getNativeObject();
-    assertSame(messageSchema.getKeySchema(), recordSchema.getKeySchema());
-    assertSame(messageValue.getKey(), recordValue.getKey());
+    GenericData.Record key =
+        Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+    assertEquals(
+        key.toString(),
+        "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}");
   }
 
   @Test
@@ -61,18 +62,32 @@ public class MergeKeyValueStepTest {
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 
-    JsonNode read = (JsonNode) messageValue.getValue();
-    assertEquals(read.get("keyField1").asText(), "key1");
-    assertEquals(read.get("keyField2").asText(), "key2");
-    assertEquals(read.get("keyField3").asText(), "key3");
-    assertEquals(read.get("valueField1").asText(), "value1");
-    assertEquals(read.get("valueField2").asText(), "value2");
-    assertEquals(read.get("valueField3").asText(), "value3");
+    assertEquals(
+        messageSchema.getKeySchema().getNativeSchema().orElseThrow().toString(),
+        "{\"type\":\"record\","
+            + "\"name\":\"record\",\"fields\":[{\"name\":\"keyField1\",\"type\":\"string\"},{\"name\":\"keyField2\","
+            + "\"type\":\"string\"},{\"name\":\"keyField3\",\"type\":\"string\"}]}");
 
-    KeyValueSchema<?, ?> recordSchema = (KeyValueSchema) record.getSchema();
-    KeyValue<?, ?> recordValue = (KeyValue<?, ?>) record.getValue().getNativeObject();
-    assertSame(messageSchema.getKeySchema(), recordSchema.getKeySchema());
-    assertSame(messageValue.getKey(), recordValue.getKey());
+    assertEquals(
+        messageSchema.getValueSchema().getNativeSchema().orElseThrow().toString(),
+        "{\"type\":\"record\","
+            + "\"name\":\"record\",\"fields\":[{\"name\":\"keyField1\",\"type\":\"string\"},{\"name\":\"keyField2\","
+            + "\"type\":\"string\"},{\"name\":\"keyField3\",\"type\":\"string\"},{\"name\":\"valueField1\","
+            + "\"type\":\"string\"},{\"name\":\"valueField2\",\"type\":\"string\"},{\"name\":\"valueField3\","
+            + "\"type\":\"string\"}]}");
+
+    JsonNode value = (JsonNode) messageValue.getValue();
+    assertEquals(value.get("keyField1").asText(), "key1");
+    assertEquals(value.get("keyField2").asText(), "key2");
+    assertEquals(value.get("keyField3").asText(), "key3");
+    assertEquals(value.get("valueField1").asText(), "value1");
+    assertEquals(value.get("valueField2").asText(), "value2");
+    assertEquals(value.get("valueField3").asText(), "value3");
+
+    JsonNode key = (JsonNode) messageValue.getKey();
+    assertEquals(key.get("keyField1").asText(), "key1");
+    assertEquals(key.get("keyField2").asText(), "key2");
+    assertEquals(key.get("keyField3").asText(), "key3");
   }
 
   @Test

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/QueryStepTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/QueryStepTest.java
@@ -62,7 +62,7 @@ public class QueryStepTest {
           public List<Map<String, String>> fetchData(String query, List<Object> params) {
             assertEquals(query, "select 1");
             List<Object> expectedParams =
-                List.of("test-message", "test-context-topic", "test-key", "test-input-topic", 42L);
+                List.of("test-message", "test-output-topic", "test-key", "test-input-topic", 42L);
             assertEquals(params, expectedParams);
             return List.of(Map.of());
           }

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
@@ -75,9 +75,9 @@ public class Utils {
       throws Exception {
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        TransformFunction.newTransformContext(context, record.getValue().getNativeObject());
     step.process(transformContext);
-    return transformContext.send();
+    return TransformFunction.send(context, transformContext);
   }
 
   public static GenericData.Record getRecord(Schema<?> schema, byte[] value) throws IOException {
@@ -316,7 +316,7 @@ public class Utils {
             AutoConsumeSchema.wrapPrimitiveObject(
                 value, schema.getSchemaInfo().getType(), new byte[] {}),
             key);
-    return new TransformContext(
+    return TransformFunction.newTransformContext(
         new Utils.TestContext(record, new HashMap<>()), record.getValue().getNativeObject());
   }
 

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapterTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/JstlTransformContextAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.pulsar.functions.transforms.jstl;
 
+import static com.datastax.oss.pulsar.functions.transforms.TransformFunction.newTransformContext;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -57,7 +58,7 @@ public class JstlTransformContextAdapterTest {
     */
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        newTransformContext(context, record.getValue().getNativeObject());
 
     // when
     JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
@@ -129,7 +130,7 @@ public class JstlTransformContextAdapterTest {
     */
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        newTransformContext(context, record.getValue().getNativeObject());
 
     // when
     JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
@@ -159,7 +160,7 @@ public class JstlTransformContextAdapterTest {
     */
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        newTransformContext(context, record.getValue().getNativeObject());
 
     // when
     JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
@@ -193,7 +194,7 @@ public class JstlTransformContextAdapterTest {
 
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        newTransformContext(context, record.getValue().getNativeObject());
 
     // when
     JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
@@ -233,7 +234,7 @@ public class JstlTransformContextAdapterTest {
     Record<GenericObject> record = new Utils.TestRecord<>(pulsarValueSchema, valueRecord, "key");
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        newTransformContext(context, record.getValue().getNativeObject());
 
     // when
     JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/predicate/JstlPredicateTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/jstl/predicate/JstlPredicateTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.pulsar.functions.transforms.jstl.predicate;
 
+import static com.datastax.oss.pulsar.functions.transforms.TransformFunction.newTransformContext;
 import static org.testng.AssertJUnit.assertEquals;
 
 import com.datastax.oss.pulsar.functions.transforms.TransformContext;
@@ -38,7 +39,7 @@ public class JstlPredicateTest {
     Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(2);
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        newTransformContext(context, record.getValue().getNativeObject());
 
     assertEquals(predicate.test(transformContext), match);
   }
@@ -53,7 +54,7 @@ public class JstlPredicateTest {
     Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(2);
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
-        new TransformContext(context, record.getValue().getNativeObject());
+        newTransformContext(context, record.getValue().getNativeObject());
 
     predicate.test(transformContext);
   }
@@ -171,7 +172,7 @@ public class JstlPredicateTest {
         new Utils.TestRecord<>(nestedKeySchema, genericNestedKeyObject, null);
 
     TransformContext nestedKeyContext =
-        new TransformContext(
+        newTransformContext(
             new Utils.TestContext(nestedKeyRecord, new HashMap<>()),
             nestedKeyRecord.getValue().getNativeObject());
 
@@ -197,7 +198,7 @@ public class JstlPredicateTest {
         new Utils.TestRecord<>(nestedValueSchema, genericNestedValueObject, null);
 
     TransformContext nestedValueContext =
-        new TransformContext(
+        newTransformContext(
             new Utils.TestContext(nestedValueRecord, new HashMap<>()),
             nestedValueRecord.getValue().getNativeObject());
     return new Object[][] {


### PR DESCRIPTION
This way the transformations are agnostics of the messaging system and could be extracted to a distinct module later.