### PR TITLE
Use a different classname for the ai-tools Function (com.datastax.oss.pulsar.functions.aitools.GenAIToolkit)

### DIFF
--- a/pulsar-ai-tools/pom.xml
+++ b/pulsar-ai-tools/pom.xml
@@ -36,6 +36,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>${pulsar.groupId}</groupId>
+      <artifactId>pulsar-functions-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>ai.djl</groupId>
       <artifactId>api</artifactId>
       <version>${djl.version}</version>
@@ -84,11 +89,6 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${pulsar.groupId}</groupId>
-      <artifactId>pulsar-functions-api</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/pulsar-ai-tools/src/main/java/com/datastax/oss/pulsar/functions/aitools/GenAIToolkit.java
+++ b/pulsar-ai-tools/src/main/java/com/datastax/oss/pulsar/functions/aitools/GenAIToolkit.java
@@ -1,0 +1,10 @@
+package com.datastax.oss.pulsar.functions.aitools;
+
+import com.datastax.oss.pulsar.functions.transforms.TransformFunction;
+
+/**
+ * This is a dummy class to allow having a different classname for the "ai-tools" function.
+ * In this module you can find a different config-schema.yaml file that unlocks the "ai-tools" function.
+ */
+public class GenAIToolkit extends TransformFunction {
+}

--- a/pulsar-ai-tools/src/main/java/com/datastax/oss/pulsar/functions/aitools/GenAIToolkit.java
+++ b/pulsar-ai-tools/src/main/java/com/datastax/oss/pulsar/functions/aitools/GenAIToolkit.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.pulsar.functions.aitools;
 
 import com.datastax.oss.pulsar.functions.transforms.TransformFunction;

--- a/pulsar-ai-tools/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-ai-tools/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -18,5 +18,5 @@
 #
 
 name: ai-tools
-description: AI tools
-functionClass: com.datastax.oss.pulsar.functions.transforms.TransformFunction
+description: Generative AI tools
+functionClass: com.datastax.oss.pulsar.functions.aitools.GenAIToolkit


### PR DESCRIPTION
Summary:
Unfortunately the Pulsar Functions API doesn't allow you to know the original name of the "type" of the builtin function.
So when you deploy the 'ai-tools' function there is no way of distinguishing it from the 'transforms' function.

This patch changes the name to com.datastax.oss.pulsar.functions.aitools.GenAIToolkit.
It is 100% compatible with the previous versions.