### PR TITLE
AstraDB datasource: allow to prepend base64: in the secureBundle option

### DIFF
--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSource.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSource.java
@@ -147,6 +147,11 @@ public class AstraDBDataSource implements QueryStepDataSource {
 
   public CqlSession buildCqlSession(String username, String password, String secureBundle) {
 
+    // Remove the base64: prefix if present
+    if (secureBundle.startsWith("base64:")) {
+      secureBundle = secureBundle.substring("base64:".length());
+    }
+
     byte[] secureBundleDecoded = Base64.getDecoder().decode(secureBundle);
     CqlSessionBuilder builder =
         new CqlSessionBuilder()


### PR DESCRIPTION
In the Datasource definition for AstraDB, remove the "base64:" prefix if present