### PR TITLE
Refactor the loading of AI ServiceProviders

### DIFF
--- a/pulsar-ai-tools/README.md
+++ b/pulsar-ai-tools/README.md
@@ -20,7 +20,6 @@ Parameters:
 | Name             | Description                                                                                                                                        |
 |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | model            | The model to use, it depends on the provider                                                                                                       |
-| compute-service  | The embeddings provider (openai, huggingface...)                                                                                                   | 
 | text             | Template for the text to compute the embeddings on. You can use the [Mustache](https://mustache.github.io/) syntax (for example {{value.field1}} ) |
 | embeddings-field | The name of the field to add or update (for example value.embeddingsvector)                                                                        |
 

--- a/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
+++ b/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
@@ -269,8 +269,8 @@ public class AIToolsTest {
         Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
     assertEquals("result", valueAvroRecord.get("completion").toString());
     assertEquals(
-        "{\"options\":{\"messages\":[{\"role\":\"user\",\"content\":\"value1 key2\"}],\"max_tokens\":null,\"temperature\":null,\"top_p\":null,\"logit_bias\":null,\"user\":null,\"n\":null,\"stop\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"stream\":null,\"model\":null},\"model\":\"test-model\"}",
-        valueAvroRecord.get("log").toString());
+        valueAvroRecord.get("log").toString(),
+        "{\"options\":{\"max_tokens\":null,\"temperature\":null,\"top_p\":null,\"logit_bias\":null,\"user\":null,\"n\":null,\"stop\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"stream\":null,\"model\":\"test-model\"},\"messages\":[{\"role\":\"user\",\"content\":\"value1 key2\"}],\"model\":\"test-model\"}");
   }
 
   @Test

--- a/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
+++ b/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
@@ -28,9 +28,9 @@ import static org.testng.Assert.assertThrows;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
-import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
 import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
+import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -198,7 +198,8 @@ public class AIToolsTest {
             .replace("'", "\"");
     when(client.getChatCompletions(eq("test-model"), any()))
         .thenReturn(new ObjectMapper().readValue(completion, ChatCompletions.class));
-    when(transformFunction.buildServiceProvider(any())).thenReturn(new OpenAIServiceProvider(client));
+    when(transformFunction.buildServiceProvider(any()))
+        .thenReturn(new OpenAIServiceProvider(client));
 
     Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
     Utils.TestContext context = new Utils.TestContext(record, config);
@@ -254,7 +255,8 @@ public class AIToolsTest {
             .replace("'", "\"");
     when(client.getChatCompletions(eq("test-model"), any()))
         .thenReturn(new ObjectMapper().readValue(completion, ChatCompletions.class));
-    when(transformFunction.buildServiceProvider(any())).thenReturn(new OpenAIServiceProvider(client));
+    when(transformFunction.buildServiceProvider(any()))
+        .thenReturn(new OpenAIServiceProvider(client));
 
     Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
     Utils.TestContext context = new Utils.TestContext(record, config);

--- a/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
+++ b/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertThrows;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
 import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -197,7 +198,7 @@ public class AIToolsTest {
             .replace("'", "\"");
     when(client.getChatCompletions(eq("test-model"), any()))
         .thenReturn(new ObjectMapper().readValue(completion, ChatCompletions.class));
-    when(transformFunction.buildOpenAIClient(any())).thenReturn(client);
+    when(transformFunction.buildServiceProvider(any())).thenReturn(new OpenAIServiceProvider(client));
 
     Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
     Utils.TestContext context = new Utils.TestContext(record, config);
@@ -253,7 +254,7 @@ public class AIToolsTest {
             .replace("'", "\"");
     when(client.getChatCompletions(eq("test-model"), any()))
         .thenReturn(new ObjectMapper().readValue(completion, ChatCompletions.class));
-    when(transformFunction.buildOpenAIClient(any())).thenReturn(client);
+    when(transformFunction.buildServiceProvider(any())).thenReturn(new OpenAIServiceProvider(client));
 
     Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
     Utils.TestContext context = new Utils.TestContext(record, config);

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -134,6 +134,7 @@ public class TransformFunction
   private List<StepPredicatePair> steps;
   private TransformStepConfig transformConfig;
   private QueryStepDataSource dataSource;
+  private ServiceProvider serviceProvider;
 
   @Override
   @SneakyThrows
@@ -213,7 +214,7 @@ public class TransformFunction
 
     transformConfig = mapper.convertValue(userConfigMap, TransformStepConfig.class);
 
-    ServiceProvider serviceProvider = buildServiceProvider(transformConfig);
+    serviceProvider = buildServiceProvider(transformConfig);
     dataSource = buildDataSource(transformConfig.getDatasource());
 
     steps = getTransformSteps(transformConfig, serviceProvider, dataSource);
@@ -223,6 +224,9 @@ public class TransformFunction
   public void close() throws Exception {
     if (dataSource != null) {
       dataSource.close();
+    }
+    if (serviceProvider != null) {
+      serviceProvider.close();
     }
     for (StepPredicatePair pair : steps) {
       pair.getTransformStep().close();

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -460,11 +460,13 @@ public class TransformFunction
   }
 
   protected ServiceProvider buildServiceProvider(TransformStepConfig config) {
-    if (config.getOpenai() != null) {
-      return new OpenAIServiceProvider(config);
-    }
-    if (config.getHuggingface() != null) {
-      return new HuggingFaceServiceProvider(config);
+    if (config != null) {
+      if (config.getOpenai() != null) {
+        return new OpenAIServiceProvider(config);
+      }
+      if (config.getHuggingface() != null) {
+        return new HuggingFaceServiceProvider(config);
+      }
     }
     return new ServiceProvider.NoopServiceProvider();
   }

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -20,7 +20,6 @@ import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getTransf
 import com.datastax.oss.streaming.ai.JsonNodeSchema;
 import com.datastax.oss.streaming.ai.TransformContext;
 import com.datastax.oss.streaming.ai.TransformStep;
-import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.services.HuggingFaceServiceProvider;
 import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -20,13 +20,13 @@ import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getTransf
 import com.datastax.oss.streaming.ai.JsonNodeSchema;
 import com.datastax.oss.streaming.ai.TransformContext;
 import com.datastax.oss.streaming.ai.TransformStep;
-import com.datastax.oss.streaming.ai.services.HuggingFaceServiceProvider;
-import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
 import com.datastax.oss.streaming.ai.jstl.predicate.StepPredicatePair;
 import com.datastax.oss.streaming.ai.model.TransformSchemaType;
 import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
 import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
+import com.datastax.oss.streaming.ai.services.HuggingFaceServiceProvider;
+import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
 import com.datastax.oss.streaming.ai.services.ServiceProvider;
 import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;

--- a/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/pulsar-transformations/src/main/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -17,16 +17,18 @@ package com.datastax.oss.pulsar.functions.transforms;
 
 import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getTransformSteps;
 
-import com.azure.ai.openai.OpenAIClient;
 import com.datastax.oss.streaming.ai.JsonNodeSchema;
 import com.datastax.oss.streaming.ai.TransformContext;
 import com.datastax.oss.streaming.ai.TransformStep;
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.services.HuggingFaceServiceProvider;
+import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
 import com.datastax.oss.streaming.ai.jstl.predicate.StepPredicatePair;
 import com.datastax.oss.streaming.ai.model.TransformSchemaType;
 import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
-import com.datastax.oss.streaming.ai.model.config.OpenAIConfig;
 import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
+import com.datastax.oss.streaming.ai.services.ServiceProvider;
 import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,6 +47,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
@@ -134,6 +138,7 @@ public class TransformFunction
   private QueryStepDataSource dataSource;
 
   @Override
+  @SneakyThrows
   public void initialize(Context context) {
     Map<String, Object> userConfigMap = context.getUserConfigMap();
     ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -209,9 +214,11 @@ public class TransformFunction
     }
 
     transformConfig = mapper.convertValue(userConfigMap, TransformStepConfig.class);
-    OpenAIClient openAIClient = buildOpenAIClient(transformConfig.getOpenai());
+
+    ServiceProvider serviceProvider = buildServiceProvider(transformConfig);
     dataSource = buildDataSource(transformConfig.getDatasource());
-    steps = getTransformSteps(transformConfig, openAIClient, dataSource);
+
+    steps = getTransformSteps(transformConfig, serviceProvider, dataSource);
   }
 
   @Override
@@ -450,8 +457,14 @@ public class TransformFunction
     return Pattern.compile("(?:^|-)(.)").matcher(kebab).replaceAll(mr -> mr.group(1).toUpperCase());
   }
 
-  protected OpenAIClient buildOpenAIClient(OpenAIConfig openAIConfig) {
-    return TransformFunctionUtil.buildOpenAIClient(openAIConfig);
+  protected ServiceProvider buildServiceProvider(TransformStepConfig config) {
+    if (config.getOpenai() != null) {
+      return new OpenAIServiceProvider(config);
+    }
+    if (config.getHuggingface() != null) {
+      return new HuggingFaceServiceProvider(config);
+    }
+    return new ServiceProvider.NoopServiceProvider();
   }
 
   protected QueryStepDataSource buildDataSource(DataSourceConfig dataSourceConfig) {

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
@@ -19,6 +19,7 @@ import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
 import com.azure.ai.openai.models.ChatMessage;
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.model.JsonRecord;
 import com.datastax.oss.streaming.ai.model.config.ChatCompletionsConfig;
 import com.samskivert.mustache.Mustache;
@@ -32,7 +33,7 @@ import org.apache.avro.Schema;
 
 public class ChatCompletionsStep implements TransformStep {
 
-  private final OpenAIClient client;
+  private final CompletionsService completionsService;
   private final ChatCompletionsConfig config;
 
   private final Map<Schema, Schema> avroValueSchemaCache = new ConcurrentHashMap<>();
@@ -41,8 +42,8 @@ public class ChatCompletionsStep implements TransformStep {
 
   private final Map<ChatMessage, Template> messageTemplates = new ConcurrentHashMap<>();
 
-  public ChatCompletionsStep(OpenAIClient client, ChatCompletionsConfig config) {
-    this.client = client;
+  public ChatCompletionsStep(CompletionsService completionsService, ChatCompletionsConfig config) {
+    this.completionsService = completionsService;
     this.config = config;
     config
         .getMessages()
@@ -78,7 +79,7 @@ public class ChatCompletionsStep implements TransformStep {
             .setFrequencyPenalty(config.getFrequencyPenalty());
 
     ChatCompletions chatCompletions =
-        client.getChatCompletions(config.getModel(), chatCompletionsOptions);
+        completionsService.getChatCompletions(config.getModel(), chatCompletionsOptions);
 
     String content = chatCompletions.getChoices().get(0).getMessage().getContent();
     String fieldName = config.getFieldName();

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
@@ -15,9 +15,11 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import com.azure.ai.openai.models.ChatCompletions;
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.convertToMap;
+
 import com.azure.ai.openai.models.ChatCompletionsOptions;
-import com.azure.ai.openai.models.ChatMessage;
+import com.datastax.oss.streaming.ai.completions.ChatCompletions;
+import com.datastax.oss.streaming.ai.completions.ChatMessage;
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.model.JsonRecord;
 import com.datastax.oss.streaming.ai.model.config.ChatCompletionsConfig;
@@ -67,7 +69,7 @@ public class ChatCompletionsStep implements TransformStep {
             .collect(Collectors.toList());
 
     ChatCompletionsOptions chatCompletionsOptions =
-        new ChatCompletionsOptions(messages)
+        new ChatCompletionsOptions(List.of())
             .setMaxTokens(config.getMaxTokens())
             .setTemperature(config.getTemperature())
             .setTopP(config.getTopP())
@@ -76,9 +78,10 @@ public class ChatCompletionsStep implements TransformStep {
             .setStop(config.getStop())
             .setPresencePenalty(config.getPresencePenalty())
             .setFrequencyPenalty(config.getFrequencyPenalty());
+    Map<String, Object> options = convertToMap(chatCompletionsOptions);
+    options.put("model", config.getModel());
 
-    ChatCompletions chatCompletions =
-        completionsService.getChatCompletions(config.getModel(), chatCompletionsOptions);
+    ChatCompletions chatCompletions = completionsService.getChatCompletions(messages, options);
 
     String content = chatCompletions.getChoices().get(0).getMessage().getContent();
     String fieldName = config.getFieldName();

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
@@ -97,6 +97,7 @@ public class ChatCompletionsStep implements TransformStep {
       Map<String, Object> logMap = new HashMap<>();
       logMap.put("model", config.getModel());
       logMap.put("options", chatCompletionsOptions);
+      logMap.put("messages", messages);
       transformContext.setResultField(
           TransformContext.toJson(logMap),
           logField,

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
 import com.azure.ai.openai.models.ChatMessage;

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
@@ -80,6 +80,7 @@ public class ChatCompletionsStep implements TransformStep {
             .setFrequencyPenalty(config.getFrequencyPenalty());
     Map<String, Object> options = convertToMap(chatCompletionsOptions);
     options.put("model", config.getModel());
+    options.remove("messages");
 
     ChatCompletions chatCompletions = completionsService.getChatCompletions(messages, options);
 
@@ -96,7 +97,7 @@ public class ChatCompletionsStep implements TransformStep {
     if (logField != null && !logField.isEmpty()) {
       Map<String, Object> logMap = new HashMap<>();
       logMap.put("model", config.getModel());
-      logMap.put("options", chatCompletionsOptions);
+      logMap.put("options", options);
       logMap.put("messages", messages);
       transformContext.setResultField(
           TransformContext.toJson(logMap),

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/ChatChoice.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/ChatChoice.java
@@ -15,9 +15,15 @@
  */
 package com.datastax.oss.streaming.ai.completions;
 
-import java.util.List;
-import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public interface CompletionsService {
-  ChatCompletions getChatCompletions(List<ChatMessage> message, Map<String, Object> options);
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatChoice {
+  private ChatMessage message;
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/ChatCompletions.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/ChatCompletions.java
@@ -16,8 +16,9 @@
 package com.datastax.oss.streaming.ai.completions;
 
 import java.util.List;
-import java.util.Map;
+import lombok.Data;
 
-public interface CompletionsService {
-  ChatCompletions getChatCompletions(List<ChatMessage> message, Map<String, Object> options);
+@Data
+public class ChatCompletions {
+  List<ChatChoice> choices;
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/ChatMessage.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/ChatMessage.java
@@ -15,9 +15,39 @@
  */
 package com.datastax.oss.streaming.ai.completions;
 
-import java.util.List;
-import java.util.Map;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-public interface CompletionsService {
-  ChatCompletions getChatCompletions(List<ChatMessage> message, Map<String, Object> options);
+@ToString
+@NoArgsConstructor
+public class ChatMessage {
+  private String role;
+  private String content;
+
+  public ChatMessage(String role, String content) {
+    this.role = role;
+    this.content = content;
+  }
+
+  public ChatMessage(String role) {
+    this.role = role;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
+  public ChatMessage setRole(String role) {
+    this.role = role;
+    return this;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public ChatMessage setContent(String content) {
+    this.content = content;
+    return this;
+  }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/CompletionsService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/CompletionsService.java
@@ -1,0 +1,15 @@
+package com.datastax.oss.streaming.ai.completions;
+
+import com.azure.ai.openai.models.ChatCompletions;
+import com.azure.ai.openai.models.ChatCompletionsOptions;
+
+public interface CompletionsService {
+    ChatCompletions getChatCompletions(String model, ChatCompletionsOptions chatCompletionsOptions);
+
+    public static class NoopCompletionService implements CompletionsService {
+        @Override
+        public ChatCompletions getChatCompletions(String model, ChatCompletionsOptions chatCompletionsOptions) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/CompletionsService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/CompletionsService.java
@@ -21,11 +21,4 @@ import com.azure.ai.openai.models.ChatCompletionsOptions;
 public interface CompletionsService {
   ChatCompletions getChatCompletions(String model, ChatCompletionsOptions chatCompletionsOptions);
 
-  public static class NoopCompletionService implements CompletionsService {
-    @Override
-    public ChatCompletions getChatCompletions(
-        String model, ChatCompletionsOptions chatCompletionsOptions) {
-      throw new UnsupportedOperationException();
-    }
-  }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/CompletionsService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/CompletionsService.java
@@ -1,15 +1,31 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.streaming.ai.completions;
 
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
 
 public interface CompletionsService {
-    ChatCompletions getChatCompletions(String model, ChatCompletionsOptions chatCompletionsOptions);
+  ChatCompletions getChatCompletions(String model, ChatCompletionsOptions chatCompletionsOptions);
 
-    public static class NoopCompletionService implements CompletionsService {
-        @Override
-        public ChatCompletions getChatCompletions(String model, ChatCompletionsOptions chatCompletionsOptions) {
-            throw new UnsupportedOperationException();
-        }
+  public static class NoopCompletionService implements CompletionsService {
+    @Override
+    public ChatCompletions getChatCompletions(
+        String model, ChatCompletionsOptions chatCompletionsOptions) {
+      throw new UnsupportedOperationException();
     }
+  }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.streaming.ai.completions;
 
 import com.azure.ai.openai.OpenAIClient;
@@ -6,13 +21,15 @@ import com.azure.ai.openai.models.ChatCompletionsOptions;
 
 public class OpenAICompletionService implements CompletionsService {
 
-    private OpenAIClient client;
-    public OpenAICompletionService(OpenAIClient client) {
-        this.client = client;
-    }
+  private OpenAIClient client;
 
-    @Override
-    public ChatCompletions getChatCompletions(String model, ChatCompletionsOptions chatCompletionsOptions) {
-        return client.getChatCompletions(model, chatCompletionsOptions);
-    }
+  public OpenAICompletionService(OpenAIClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public ChatCompletions getChatCompletions(
+      String model, ChatCompletionsOptions chatCompletionsOptions) {
+    return client.getChatCompletions(model, chatCompletionsOptions);
+  }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
@@ -15,9 +15,15 @@
  */
 package com.datastax.oss.streaming.ai.completions;
 
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.convertFromMap;
+
 import com.azure.ai.openai.OpenAIClient;
-import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.azure.ai.openai.models.ChatRole;
+import com.datastax.oss.streaming.ai.model.config.ChatCompletionsConfig;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class OpenAICompletionService implements CompletionsService {
 
@@ -29,7 +35,39 @@ public class OpenAICompletionService implements CompletionsService {
 
   @Override
   public ChatCompletions getChatCompletions(
-      String model, ChatCompletionsOptions chatCompletionsOptions) {
-    return client.getChatCompletions(model, chatCompletionsOptions);
+      List<ChatMessage> messages, Map<String, Object> options) {
+    ChatCompletionsConfig config = convertFromMap(options, ChatCompletionsConfig.class);
+    ChatCompletionsOptions chatCompletionsOptions =
+        new ChatCompletionsOptions(
+                messages
+                    .stream()
+                    .map(
+                        message ->
+                            new com.azure.ai.openai.models.ChatMessage(
+                                    ChatRole.fromString(message.getRole()))
+                                .setContent(message.getContent()))
+                    .collect(Collectors.toList()))
+            .setMaxTokens(config.getMaxTokens())
+            .setTemperature(config.getTemperature())
+            .setTopP(config.getTopP())
+            .setLogitBias(config.getLogitBias())
+            .setUser(config.getUser())
+            .setStop(config.getStop())
+            .setPresencePenalty(config.getPresencePenalty())
+            .setFrequencyPenalty(config.getFrequencyPenalty());
+    com.azure.ai.openai.models.ChatCompletions chatCompletions =
+        client.getChatCompletions(config.getModel(), chatCompletionsOptions);
+    ChatCompletions result = new ChatCompletions();
+    result.setChoices(
+        chatCompletions
+            .getChoices()
+            .stream()
+            .map(
+                c ->
+                    new ChatChoice(
+                        new ChatMessage(
+                            c.getMessage().getRole().toString(), c.getMessage().getContent())))
+            .collect(Collectors.toList()));
+    return result;
   }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
@@ -1,0 +1,18 @@
+package com.datastax.oss.streaming.ai.completions;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.models.ChatCompletions;
+import com.azure.ai.openai.models.ChatCompletionsOptions;
+
+public class OpenAICompletionService implements CompletionsService {
+
+    private OpenAIClient client;
+    public OpenAICompletionService(OpenAIClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public ChatCompletions getChatCompletions(String model, ChatCompletionsOptions chatCompletionsOptions) {
+        return client.getChatCompletions(model, chatCompletionsOptions);
+    }
+}

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/config/ChatCompletionsConfig.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/config/ChatCompletionsConfig.java
@@ -15,7 +15,7 @@
  */
 package com.datastax.oss.streaming.ai.model.config;
 
-import com.azure.ai.openai.models.ChatMessage;
+import com.datastax.oss.streaming.ai.completions.ChatMessage;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeAIEmbeddingsConfig.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeAIEmbeddingsConfig.java
@@ -36,6 +36,7 @@ public class ComputeAIEmbeddingsConfig extends StepConfig {
   @JsonProperty(value = "embeddings-field", required = true)
   private String embeddingsFieldName;
 
+  @Deprecated
   @JsonProperty(value = "compute-service")
   private String service;
 

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
@@ -1,0 +1,88 @@
+package com.datastax.oss.streaming.ai.services;
+
+import com.datastax.oss.driver.shaded.guava.common.base.Strings;
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService;
+import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+import com.datastax.oss.streaming.ai.embeddings.HuggingFaceEmbeddingService;
+import com.datastax.oss.streaming.ai.embeddings.HuggingFaceRestEmbeddingService;
+import com.datastax.oss.streaming.ai.model.config.ComputeProvider;
+import com.datastax.oss.streaming.ai.model.config.HuggingFaceConfig;
+import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService.DLJ_BASE_URL;
+
+@Slf4j
+public class HuggingFaceServiceProvider implements ServiceProvider {
+
+    private final Map<String, Object> providerConfiguration;
+
+    public HuggingFaceServiceProvider(Map<String, Object> providerConfiguration) {
+        this.providerConfiguration = providerConfiguration;
+    }
+
+    public HuggingFaceServiceProvider(TransformStepConfig tranformConfiguration) {
+        this.providerConfiguration =
+                new ObjectMapper().convertValue(tranformConfiguration.getHuggingface(), Map.class);
+    }
+
+    @Override
+    public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
+        throw new IllegalArgumentException("Completions is still not available for HuggingFace");
+    }
+
+    @Override
+    public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) throws Exception {
+        String provider = additionalConfiguration.getOrDefault("provider", ComputeProvider.API.name()).toString().toUpperCase();
+        String modelUrl = (String) additionalConfiguration.get("modelUrl");
+        String model = (String) additionalConfiguration.get("model");
+        Map<String, String> options = (Map<String, String>) additionalConfiguration.get("options");
+        Map<String, String> arguments = (Map<String, String>) additionalConfiguration.get("arguments");
+        switch (provider) {
+            case "LOCAL":
+                AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.HuggingFaceConfigBuilder builder =
+                        AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.builder()
+                                .options(options)
+                                .arguments(arguments);
+                if (!Strings.isNullOrEmpty(model)) {
+                    builder.modelName(model);
+
+                    // automatically build the model URL if not provided
+                    if (Strings.isNullOrEmpty(modelUrl)) {
+                        modelUrl = DLJ_BASE_URL + model;
+                        log.info("Automatically computed model URL {}", modelUrl);
+                    }
+                }
+                builder.modelUrl(modelUrl);
+
+                return new HuggingFaceEmbeddingService(builder.build());
+            case "API":
+                Objects.requireNonNull(model, "model name is required");
+                HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.HuggingFaceApiConfigBuilder
+                        apiBuilder =
+                        HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.builder()
+                                .accessKey((String) providerConfiguration.get("access-key"))
+                                .model(model);
+
+                String apiUurl = (String) providerConfiguration.get("api-url");
+                if (!Strings.isNullOrEmpty(apiUurl)) {
+                    apiBuilder.hfUrl(apiUurl);
+                }
+                if (options != null && !options.isEmpty()) {
+                    apiBuilder.options(options);
+                } else {
+                    apiBuilder.options(Map.of("wait_for_model", "true"));
+                }
+
+                return new HuggingFaceRestEmbeddingService(apiBuilder.build());
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported HuggingFace service type: " + provider);
+        }
+    }
+}

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
@@ -1,4 +1,21 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.streaming.ai.services;
+
+import static com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService.DLJ_BASE_URL;
 
 import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
@@ -7,82 +24,82 @@ import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
 import com.datastax.oss.streaming.ai.embeddings.HuggingFaceEmbeddingService;
 import com.datastax.oss.streaming.ai.embeddings.HuggingFaceRestEmbeddingService;
 import com.datastax.oss.streaming.ai.model.config.ComputeProvider;
-import com.datastax.oss.streaming.ai.model.config.HuggingFaceConfig;
 import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Map;
 import java.util.Objects;
-
-import static com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService.DLJ_BASE_URL;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class HuggingFaceServiceProvider implements ServiceProvider {
 
-    private final Map<String, Object> providerConfiguration;
+  private final Map<String, Object> providerConfiguration;
 
-    public HuggingFaceServiceProvider(Map<String, Object> providerConfiguration) {
-        this.providerConfiguration = providerConfiguration;
-    }
+  public HuggingFaceServiceProvider(Map<String, Object> providerConfiguration) {
+    this.providerConfiguration = providerConfiguration;
+  }
 
-    public HuggingFaceServiceProvider(TransformStepConfig tranformConfiguration) {
-        this.providerConfiguration =
-                new ObjectMapper().convertValue(tranformConfiguration.getHuggingface(), Map.class);
-    }
+  public HuggingFaceServiceProvider(TransformStepConfig tranformConfiguration) {
+    this.providerConfiguration =
+        new ObjectMapper().convertValue(tranformConfiguration.getHuggingface(), Map.class);
+  }
 
-    @Override
-    public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
-        throw new IllegalArgumentException("Completions is still not available for HuggingFace");
-    }
+  @Override
+  public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
+    throw new IllegalArgumentException("Completions is still not available for HuggingFace");
+  }
 
-    @Override
-    public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) throws Exception {
-        String provider = additionalConfiguration.getOrDefault("provider", ComputeProvider.API.name()).toString().toUpperCase();
-        String modelUrl = (String) additionalConfiguration.get("modelUrl");
-        String model = (String) additionalConfiguration.get("model");
-        Map<String, String> options = (Map<String, String>) additionalConfiguration.get("options");
-        Map<String, String> arguments = (Map<String, String>) additionalConfiguration.get("arguments");
-        switch (provider) {
-            case "LOCAL":
-                AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.HuggingFaceConfigBuilder builder =
-                        AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.builder()
-                                .options(options)
-                                .arguments(arguments);
-                if (!Strings.isNullOrEmpty(model)) {
-                    builder.modelName(model);
+  @Override
+  public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration)
+      throws Exception {
+    String provider =
+        additionalConfiguration
+            .getOrDefault("provider", ComputeProvider.API.name())
+            .toString()
+            .toUpperCase();
+    String modelUrl = (String) additionalConfiguration.get("modelUrl");
+    String model = (String) additionalConfiguration.get("model");
+    Map<String, String> options = (Map<String, String>) additionalConfiguration.get("options");
+    Map<String, String> arguments = (Map<String, String>) additionalConfiguration.get("arguments");
+    switch (provider) {
+      case "LOCAL":
+        AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.HuggingFaceConfigBuilder builder =
+            AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.builder()
+                .options(options)
+                .arguments(arguments);
+        if (!Strings.isNullOrEmpty(model)) {
+          builder.modelName(model);
 
-                    // automatically build the model URL if not provided
-                    if (Strings.isNullOrEmpty(modelUrl)) {
-                        modelUrl = DLJ_BASE_URL + model;
-                        log.info("Automatically computed model URL {}", modelUrl);
-                    }
-                }
-                builder.modelUrl(modelUrl);
-
-                return new HuggingFaceEmbeddingService(builder.build());
-            case "API":
-                Objects.requireNonNull(model, "model name is required");
-                HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.HuggingFaceApiConfigBuilder
-                        apiBuilder =
-                        HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.builder()
-                                .accessKey((String) providerConfiguration.get("access-key"))
-                                .model(model);
-
-                String apiUurl = (String) providerConfiguration.get("api-url");
-                if (!Strings.isNullOrEmpty(apiUurl)) {
-                    apiBuilder.hfUrl(apiUurl);
-                }
-                if (options != null && !options.isEmpty()) {
-                    apiBuilder.options(options);
-                } else {
-                    apiBuilder.options(Map.of("wait_for_model", "true"));
-                }
-
-                return new HuggingFaceRestEmbeddingService(apiBuilder.build());
-            default:
-                throw new IllegalArgumentException(
-                        "Unsupported HuggingFace service type: " + provider);
+          // automatically build the model URL if not provided
+          if (Strings.isNullOrEmpty(modelUrl)) {
+            modelUrl = DLJ_BASE_URL + model;
+            log.info("Automatically computed model URL {}", modelUrl);
+          }
         }
+        builder.modelUrl(modelUrl);
+
+        return new HuggingFaceEmbeddingService(builder.build());
+      case "API":
+        Objects.requireNonNull(model, "model name is required");
+        HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.HuggingFaceApiConfigBuilder
+            apiBuilder =
+                HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.builder()
+                    .accessKey((String) providerConfiguration.get("access-key"))
+                    .model(model);
+
+        String apiUurl = (String) providerConfiguration.get("api-url");
+        if (!Strings.isNullOrEmpty(apiUurl)) {
+          apiBuilder.hfUrl(apiUurl);
+        }
+        if (options != null && !options.isEmpty()) {
+          apiBuilder.options(options);
+        } else {
+          apiBuilder.options(Map.of("wait_for_model", "true"));
+        }
+
+        return new HuggingFaceRestEmbeddingService(apiBuilder.build());
+      default:
+        throw new IllegalArgumentException("Unsupported HuggingFace service type: " + provider);
     }
+  }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
@@ -102,4 +102,7 @@ public class HuggingFaceServiceProvider implements ServiceProvider {
         throw new IllegalArgumentException("Unsupported HuggingFace service type: " + provider);
     }
   }
+
+  @Override
+  public void close() {}
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
@@ -1,0 +1,35 @@
+package com.datastax.oss.streaming.ai.services;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.completions.OpenAICompletionService;
+import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+import com.datastax.oss.streaming.ai.embeddings.OpenAIEmbeddingsService;
+import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
+import com.datastax.oss.streaming.ai.services.ServiceProvider;
+import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
+
+import java.util.Map;
+
+public class OpenAIServiceProvider implements ServiceProvider {
+
+    private final OpenAIClient client;
+    public OpenAIServiceProvider(TransformStepConfig config) {
+        client = TransformFunctionUtil.buildOpenAIClient(config.getOpenai());
+    }
+
+    public OpenAIServiceProvider(OpenAIClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
+        return new OpenAICompletionService(client);
+    }
+
+    @Override
+    public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
+        String model = (String) additionalConfiguration.get("model");
+        return new OpenAIEmbeddingsService(client, model);
+    }
+}

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.streaming.ai.services;
 
 import com.azure.ai.openai.OpenAIClient;
@@ -6,30 +21,29 @@ import com.datastax.oss.streaming.ai.completions.OpenAICompletionService;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
 import com.datastax.oss.streaming.ai.embeddings.OpenAIEmbeddingsService;
 import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
-import com.datastax.oss.streaming.ai.services.ServiceProvider;
 import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
-
 import java.util.Map;
 
 public class OpenAIServiceProvider implements ServiceProvider {
 
-    private final OpenAIClient client;
-    public OpenAIServiceProvider(TransformStepConfig config) {
-        client = TransformFunctionUtil.buildOpenAIClient(config.getOpenai());
-    }
+  private final OpenAIClient client;
 
-    public OpenAIServiceProvider(OpenAIClient client) {
-        this.client = client;
-    }
+  public OpenAIServiceProvider(TransformStepConfig config) {
+    client = TransformFunctionUtil.buildOpenAIClient(config.getOpenai());
+  }
 
-    @Override
-    public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
-        return new OpenAICompletionService(client);
-    }
+  public OpenAIServiceProvider(OpenAIClient client) {
+    this.client = client;
+  }
 
-    @Override
-    public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
-        String model = (String) additionalConfiguration.get("model");
-        return new OpenAIEmbeddingsService(client, model);
-    }
+  @Override
+  public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
+    return new OpenAICompletionService(client);
+  }
+
+  @Override
+  public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
+    String model = (String) additionalConfiguration.get("model");
+    return new OpenAIEmbeddingsService(client, model);
+  }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
@@ -46,4 +46,7 @@ public class OpenAIServiceProvider implements ServiceProvider {
     String model = (String) additionalConfiguration.get("model");
     return new OpenAIEmbeddingsService(client, model);
   }
+
+  @Override
+  public void close() {}
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
@@ -1,24 +1,40 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.streaming.ai.services;
 
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
-
 import java.util.Map;
 
 public interface ServiceProvider {
-    CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) throws Exception;
+  CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration)
+      throws Exception;
 
-    EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) throws Exception;
+  EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration)
+      throws Exception;
 
-    public static class NoopServiceProvider implements ServiceProvider {
-        @Override
-        public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
-            throw new IllegalArgumentException("There is no provider configured for completion service");
-        }
-
-        @Override
-        public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
-            throw new IllegalArgumentException("There is no provider configured for embeddings service");
-        }
+  public static class NoopServiceProvider implements ServiceProvider {
+    @Override
+    public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
+      throw new IllegalArgumentException("There is no provider configured for completion service");
     }
+
+    @Override
+    public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
+      throw new IllegalArgumentException("There is no provider configured for embeddings service");
+    }
+  }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
@@ -1,0 +1,24 @@
+package com.datastax.oss.streaming.ai.services;
+
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+
+import java.util.Map;
+
+public interface ServiceProvider {
+    CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) throws Exception;
+
+    EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) throws Exception;
+
+    public static class NoopServiceProvider implements ServiceProvider {
+        @Override
+        public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
+            throw new IllegalArgumentException("There is no provider configured for completion service");
+        }
+
+        @Override
+        public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
+            throw new IllegalArgumentException("There is no provider configured for embeddings service");
+        }
+    }
+}

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
@@ -17,6 +17,7 @@ package com.datastax.oss.streaming.ai.services;
 
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+import java.util.List;
 import java.util.Map;
 
 public interface ServiceProvider extends AutoCloseable {
@@ -31,12 +32,17 @@ public interface ServiceProvider extends AutoCloseable {
   public static class NoopServiceProvider implements ServiceProvider {
     @Override
     public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
-      throw new IllegalArgumentException("There is no provider configured for completion service");
+      throw new IllegalArgumentException("please configure an AI service");
     }
 
     @Override
     public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
-      throw new IllegalArgumentException("There is no provider configured for embeddings service");
+      return new EmbeddingsService() {
+        @Override
+        public List<List<Double>> computeEmbeddings(List<String> texts) {
+          return List.of();
+        }
+      };
     }
 
     @Override

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
@@ -19,12 +19,14 @@ import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
 import java.util.Map;
 
-public interface ServiceProvider {
+public interface ServiceProvider extends AutoCloseable {
   CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration)
       throws Exception;
 
   EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration)
       throws Exception;
+
+  void close();
 
   public static class NoopServiceProvider implements ServiceProvider {
     @Override
@@ -36,5 +38,8 @@ public interface ServiceProvider {
     public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
       throw new IllegalArgumentException("There is no provider configured for embeddings service");
     }
+
+    @Override
+    public void close() {}
   }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -307,4 +307,26 @@ public class TransformFunctionUtil {
     }
     return value;
   }
+
+  public static Double getDouble(String name, Map<String, Object> options) {
+    Object o = options.get(name);
+    if (o == null) {
+      return null;
+    }
+    if (o instanceof Number) {
+      return ((Number) o).doubleValue();
+    }
+    return Double.parseDouble(o.toString());
+  }
+
+  public static Integer getInteger(String name, Map<String, Object> options) {
+    Object o = options.get(name);
+    if (o == null) {
+      return null;
+    }
+    if (o instanceof Number) {
+      return ((Number) o).intValue();
+    }
+    return Integer.parseInt(o.toString());
+  }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -15,13 +15,10 @@
  */
 package com.datastax.oss.streaming.ai.util;
 
-import static com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService.DLJ_BASE_URL;
-
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.ai.openai.models.NonAzureOpenAIKeyCredential;
 import com.azure.core.credential.AzureKeyCredential;
-import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import com.datastax.oss.streaming.ai.CastStep;
 import com.datastax.oss.streaming.ai.ChatCompletionsStep;
 import com.datastax.oss.streaming.ai.ComputeAIEmbeddingsStep;
@@ -37,11 +34,7 @@ import com.datastax.oss.streaming.ai.UnwrapKeyValueStep;
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.datasource.AstraDBDataSource;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
-import com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
-import com.datastax.oss.streaming.ai.embeddings.HuggingFaceEmbeddingService;
-import com.datastax.oss.streaming.ai.embeddings.HuggingFaceRestEmbeddingService;
-import com.datastax.oss.streaming.ai.embeddings.OpenAIEmbeddingsService;
 import com.datastax.oss.streaming.ai.jstl.predicate.JstlPredicate;
 import com.datastax.oss.streaming.ai.jstl.predicate.StepPredicatePair;
 import com.datastax.oss.streaming.ai.model.ComputeField;
@@ -54,7 +47,6 @@ import com.datastax.oss.streaming.ai.model.config.ComputeConfig;
 import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
 import com.datastax.oss.streaming.ai.model.config.DropFieldsConfig;
 import com.datastax.oss.streaming.ai.model.config.FlattenConfig;
-import com.datastax.oss.streaming.ai.model.config.HuggingFaceConfig;
 import com.datastax.oss.streaming.ai.model.config.OpenAIConfig;
 import com.datastax.oss.streaming.ai.model.config.OpenAIProvider;
 import com.datastax.oss.streaming.ai.model.config.QueryConfig;
@@ -71,9 +63,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -119,7 +109,8 @@ public class TransformFunctionUtil {
   public static List<StepPredicatePair> getTransformSteps(
       TransformStepConfig transformConfig,
       ServiceProvider serviceProvider,
-      QueryStepDataSource dataSource) throws Exception {
+      QueryStepDataSource dataSource)
+      throws Exception {
     TransformStep transformStep;
     List<StepPredicatePair> steps = new ArrayList<>();
     for (StepConfig step : transformConfig.getSteps()) {
@@ -147,9 +138,7 @@ public class TransformFunctionUtil {
           transformStep = newComputeFieldFunction((ComputeConfig) step);
           break;
         case "compute-ai-embeddings":
-          transformStep =
-              newComputeAIEmbeddings(
-                  (ComputeAIEmbeddingsConfig) step, serviceProvider);
+          transformStep = newComputeAIEmbeddings((ComputeAIEmbeddingsConfig) step, serviceProvider);
           break;
         case "ai-chat-completions":
           transformStep = newChatCompletionsFunction((ChatCompletionsConfig) step, serviceProvider);
@@ -247,8 +236,7 @@ public class TransformFunctionUtil {
 
   @SneakyThrows
   public static TransformStep newComputeAIEmbeddings(
-      ComputeAIEmbeddingsConfig config,
-      ServiceProvider provider) {
+      ComputeAIEmbeddingsConfig config, ServiceProvider provider) {
     EmbeddingsService embeddingsService = provider.getEmbeddingsService(convertToMap(config));
     return new ComputeAIEmbeddingsStep(
         config.getText(), config.getEmbeddingsFieldName(), embeddingsService);
@@ -264,7 +252,8 @@ public class TransformFunctionUtil {
 
   public static TransformStep newChatCompletionsFunction(
       ChatCompletionsConfig config, ServiceProvider serviceProvider) throws Exception {
-    CompletionsService completionsService = serviceProvider.getCompletionsService(convertToMap(config));
+    CompletionsService completionsService =
+        serviceProvider.getCompletionsService(convertToMap(config));
     return new ChatCompletionsStep(completionsService, config);
   }
 

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -246,8 +246,12 @@ public class TransformFunctionUtil {
     return new UnwrapKeyValueStep(config.isUnwrapKey());
   }
 
-  private static Map<String, Object> convertToMap(Object object) {
+  public static Map<String, Object> convertToMap(Object object) {
     return new ObjectMapper().convertValue(object, Map.class);
+  }
+
+  public static <T> T convertFromMap(Map<String, Object> map, Class<T> type) {
+    return new ObjectMapper().convertValue(map, type);
   }
 
   public static TransformStep newChatCompletionsFunction(

--- a/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
+++ b/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
@@ -75,10 +75,11 @@ public class ChatCompletionsStepTest {
           .replace("'", "\"");
   private static final ObjectMapper mapper = new ObjectMapper();
   private OpenAICompletionService completionService;
+  private OpenAIClient openAIClient;
 
   @BeforeMethod
   void setup() throws Exception {
-    OpenAIClient openAIClient = mock(OpenAIClient.class);
+    openAIClient = mock(OpenAIClient.class);
     when(openAIClient.getChatCompletions(eq("test-model"), any()))
         .thenReturn(mapper.readValue(COMPLETION, ChatCompletions.class));
     this.completionService = new OpenAICompletionService(openAIClient);
@@ -109,7 +110,7 @@ public class ChatCompletionsStepTest {
                 .setContent(
                     "{{ value }} {{ key}} {{ eventTime }} {{ topicName }} {{ destinationTopic }} {{ properties.test-key }}")));
     Utils.process(record, new ChatCompletionsStep(completionService, config));
-    verify(completionService).getChatCompletions(eq("test-model"), captor.capture());
+    verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
 
     assertEquals(
         captor.getValue().getMessages().get(0).getContent(),
@@ -158,7 +159,7 @@ public class ChatCompletionsStepTest {
     Utils.process(record, new ChatCompletionsStep(completionService, config));
     ArgumentCaptor<ChatCompletionsOptions> captor =
         ArgumentCaptor.forClass(ChatCompletionsOptions.class);
-    verify(completionService).getChatCompletions(eq("test-model"), captor.capture());
+    verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
 
     assertEquals(
         captor.getValue().getMessages().get(0).getContent(),
@@ -196,7 +197,7 @@ public class ChatCompletionsStepTest {
 
     ArgumentCaptor<ChatCompletionsOptions> captor =
         ArgumentCaptor.forClass(ChatCompletionsOptions.class);
-    verify(completionService).getChatCompletions(eq("test-model"), captor.capture());
+    verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
 
     assertEquals(
         captor.getValue().getMessages().get(0).getContent(),
@@ -216,7 +217,7 @@ public class ChatCompletionsStepTest {
     Utils.process(
         Utils.createTestStructKeyValueRecord(schemaType),
         new ChatCompletionsStep(completionService, config));
-    verify(completionService).getChatCompletions(eq("test-model"), captor.capture());
+    verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
 
     assertEquals(captor.getValue().getMessages().get(0).getContent(), "value1 key2");
   }
@@ -248,7 +249,7 @@ public class ChatCompletionsStepTest {
 
     ArgumentCaptor<ChatCompletionsOptions> captor =
         ArgumentCaptor.forClass(ChatCompletionsOptions.class);
-    verify(completionService).getChatCompletions(eq("test-model"), captor.capture());
+    verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
 
     assertEquals(
         captor.getValue().getMessages().get(0).getContent(),

--- a/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
+++ b/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
@@ -25,8 +25,7 @@ import static org.testng.Assert.assertEquals;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
-import com.azure.ai.openai.models.ChatMessage;
-import com.azure.ai.openai.models.ChatRole;
+import com.datastax.oss.streaming.ai.completions.ChatMessage;
 import com.datastax.oss.streaming.ai.completions.OpenAICompletionService;
 import com.datastax.oss.streaming.ai.model.config.ChatCompletionsConfig;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -106,7 +105,7 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(
         List.of(
-            new ChatMessage(ChatRole.USER)
+            new ChatMessage("user")
                 .setContent(
                     "{{ value }} {{ key}} {{ eventTime }} {{ topicName }} {{ destinationTopic }} {{ properties.test-key }}")));
     Utils.process(record, new ChatCompletionsStep(completionService, config));
@@ -153,7 +152,7 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(
         List.of(
-            new ChatMessage(ChatRole.USER)
+            new ChatMessage("user")
                 .setContent(
                     "{{ value.firstName }} {{ value.lastName }} {{ value.age }} {{ value.date }} {{ value.timestamp }} {{ value.time }} {{ key }}")));
     Utils.process(record, new ChatCompletionsStep(completionService, config));
@@ -190,7 +189,7 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(
         List.of(
-            new ChatMessage(ChatRole.USER)
+            new ChatMessage("user")
                 .setContent(
                     "{{ value.firstName }} {{ value.lastName }} {{ value.age }} {{ value.date }} {{ value.timestamp }} {{ value.time }} {{ key }}")));
     Utils.process(record, new ChatCompletionsStep(completionService, config));
@@ -211,9 +210,7 @@ public class ChatCompletionsStepTest {
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
     config.setMessages(
-        List.of(
-            new ChatMessage(ChatRole.USER)
-                .setContent("{{ value.valueField1 }} {{ key.keyField2 }}")));
+        List.of(new ChatMessage("user").setContent("{{ value.valueField1 }} {{ key.keyField2 }}")));
     Utils.process(
         Utils.createTestStructKeyValueRecord(schemaType),
         new ChatCompletionsStep(completionService, config));
@@ -242,7 +239,7 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(
         List.of(
-            new ChatMessage(ChatRole.USER)
+            new ChatMessage("user")
                 .setContent(
                     "{{ value.firstName }} {{ value.lastName }} {{ value.age }} {{ value.date }} {{ value.timestamp }} {{ value.time }} {{ key }}")));
     Utils.process(record, new ChatCompletionsStep(completionService, config));
@@ -269,7 +266,7 @@ public class ChatCompletionsStepTest {
 
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     Record<?> outputRecord =
         Utils.process(record, new ChatCompletionsStep(completionService, config));
     assertEquals(outputRecord.getValue(), "result");
@@ -279,7 +276,7 @@ public class ChatCompletionsStepTest {
   void testKeyOutput() throws Exception {
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("key");
     Record<?> outputRecord =
         Utils.process(
@@ -304,7 +301,7 @@ public class ChatCompletionsStepTest {
             .build();
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("destinationTopic");
     Record<?> outputRecord =
         Utils.process(record, new ChatCompletionsStep(completionService, config));
@@ -323,7 +320,7 @@ public class ChatCompletionsStepTest {
             .build();
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("messageKey");
     Record<?> outputRecord =
         Utils.process(record, new ChatCompletionsStep(completionService, config));
@@ -342,7 +339,7 @@ public class ChatCompletionsStepTest {
             .build();
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("properties.chat");
     Record<?> outputRecord =
         Utils.process(record, new ChatCompletionsStep(completionService, config));
@@ -353,7 +350,7 @@ public class ChatCompletionsStepTest {
   void testAvroValueFieldOutput() throws Exception {
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("value.chat");
     Record<?> outputRecord =
         Utils.process(
@@ -371,7 +368,7 @@ public class ChatCompletionsStepTest {
   void testJsonValueFieldOutput() throws Exception {
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("value.chat");
     Record<?> outputRecord =
         Utils.process(
@@ -410,7 +407,7 @@ public class ChatCompletionsStepTest {
 
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("value.chat");
     Record<?> outputRecord =
         Utils.process(record, new ChatCompletionsStep(completionService, config));
@@ -423,7 +420,7 @@ public class ChatCompletionsStepTest {
   void testAvroKeyFieldOutput() throws Exception {
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("key.chat");
     Record<?> outputRecord =
         Utils.process(
@@ -441,7 +438,7 @@ public class ChatCompletionsStepTest {
   void testJsonKeyFieldOutput() throws Exception {
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("key.chat");
     Record<?> outputRecord =
         Utils.process(
@@ -472,7 +469,7 @@ public class ChatCompletionsStepTest {
 
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
-    config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
+    config.setMessages(List.of(new ChatMessage("user").setContent("content")));
     config.setFieldName("key.chat");
     Record<?> outputRecord =
         Utils.process(record, new ChatCompletionsStep(completionService, config));

--- a/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
+++ b/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
@@ -269,7 +269,8 @@ public class ChatCompletionsStepTest {
     ChatCompletionsConfig config = new ChatCompletionsConfig();
     config.setModel("test-model");
     config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
-    Record<?> outputRecord = Utils.process(record, new ChatCompletionsStep(completionService, config));
+    Record<?> outputRecord =
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
     assertEquals(outputRecord.getValue(), "result");
   }
 
@@ -281,7 +282,8 @@ public class ChatCompletionsStepTest {
     config.setFieldName("key");
     Record<?> outputRecord =
         Utils.process(
-            Utils.createTestAvroKeyValueRecord(), new ChatCompletionsStep(completionService, config));
+            Utils.createTestAvroKeyValueRecord(),
+            new ChatCompletionsStep(completionService, config));
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 
@@ -303,7 +305,8 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
     config.setFieldName("destinationTopic");
-    Record<?> outputRecord = Utils.process(record, new ChatCompletionsStep(completionService, config));
+    Record<?> outputRecord =
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
     assertEquals(outputRecord.getDestinationTopic().orElseThrow(), "result");
   }
 
@@ -321,7 +324,8 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
     config.setFieldName("messageKey");
-    Record<?> outputRecord = Utils.process(record, new ChatCompletionsStep(completionService, config));
+    Record<?> outputRecord =
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
     assertEquals(outputRecord.getKey().orElseThrow(), "result");
   }
 
@@ -339,7 +343,8 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
     config.setFieldName("properties.chat");
-    Record<?> outputRecord = Utils.process(record, new ChatCompletionsStep(completionService, config));
+    Record<?> outputRecord =
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
     assertEquals(outputRecord.getProperties().get("chat"), "result");
   }
 
@@ -351,7 +356,8 @@ public class ChatCompletionsStepTest {
     config.setFieldName("value.chat");
     Record<?> outputRecord =
         Utils.process(
-            Utils.createTestAvroKeyValueRecord(), new ChatCompletionsStep(completionService, config));
+            Utils.createTestAvroKeyValueRecord(),
+            new ChatCompletionsStep(completionService, config));
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 
@@ -368,7 +374,8 @@ public class ChatCompletionsStepTest {
     config.setFieldName("value.chat");
     Record<?> outputRecord =
         Utils.process(
-            Utils.createTestJsonKeyValueRecord(), new ChatCompletionsStep(completionService, config));
+            Utils.createTestJsonKeyValueRecord(),
+            new ChatCompletionsStep(completionService, config));
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 
@@ -404,7 +411,8 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
     config.setFieldName("value.chat");
-    Record<?> outputRecord = Utils.process(record, new ChatCompletionsStep(completionService, config));
+    Record<?> outputRecord =
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
 
     assertEquals(outputRecord.getSchema(), schema);
     assertEquals(outputRecord.getValue(), expected);
@@ -418,7 +426,8 @@ public class ChatCompletionsStepTest {
     config.setFieldName("key.chat");
     Record<?> outputRecord =
         Utils.process(
-            Utils.createTestAvroKeyValueRecord(), new ChatCompletionsStep(completionService, config));
+            Utils.createTestAvroKeyValueRecord(),
+            new ChatCompletionsStep(completionService, config));
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 
@@ -435,7 +444,8 @@ public class ChatCompletionsStepTest {
     config.setFieldName("key.chat");
     Record<?> outputRecord =
         Utils.process(
-            Utils.createTestJsonKeyValueRecord(), new ChatCompletionsStep(completionService, config));
+            Utils.createTestJsonKeyValueRecord(),
+            new ChatCompletionsStep(completionService, config));
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 
@@ -463,7 +473,8 @@ public class ChatCompletionsStepTest {
     config.setModel("test-model");
     config.setMessages(List.of(new ChatMessage(ChatRole.USER).setContent("content")));
     config.setFieldName("key.chat");
-    Record<?> outputRecord = Utils.process(record, new ChatCompletionsStep(completionService, config));
+    Record<?> outputRecord =
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
     KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
     KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -65,7 +65,7 @@
             <configuration>
               <tasks>
                 <echo>copy proxy protocol handler</echo>
-                <copy file="${basedir}/../pulsar-transformations/target/pulsar-transformations-${project.version}.nar" tofile="${project.build.outputDirectory}/pulsar-transformations.nar" />
+                <copy file="${basedir}/../pulsar-transformations/target/pulsar-transformations-${project.version}.nar" tofile="${project.build.outputDirectory}/pulsar-transformations.nar"/>
               </tasks>
             </configuration>
           </execution>


### PR DESCRIPTION
Goals:
allow in SGA to plug new implementations for the EmbeddingsService and for the ChatCompletion step

Summary:
- introduce a new ServiceProvider interface and the implementation for HuggingFace and OpenAI
- introduce a CompletionService interface, do not use OpenAI classes for modelling the configuration
- the configuration is still 100% compatible