### PR TITLE
HuggingFace: Do not rely on third party shaded library

### DIFF
--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/embeddings/AbstractHuggingFaceEmbeddingService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/embeddings/AbstractHuggingFaceEmbeddingService.java
@@ -22,7 +22,6 @@ import ai.djl.repository.zoo.Criteria;
 import ai.djl.repository.zoo.ModelNotFoundException;
 import ai.djl.repository.zoo.ZooModel;
 import ai.djl.translate.TranslateException;
-import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
@@ -49,10 +48,10 @@ public abstract class AbstractHuggingFaceEmbeddingService<IN, OUT>
 
   private static Set<String> getHuggingFaceAllowedUrlPrefixes() {
     String prop = System.getenv(URL_PREFIXES_SYSTEM_PROP);
-    if (Strings.isNullOrEmpty(prop)) {
+    if (prop == null || prop.isEmpty()) {
       prop = System.getProperty(URL_PREFIXES_SYSTEM_PROP);
     }
-    if (Strings.isNullOrEmpty(prop)) {
+    if (prop == null || prop.isEmpty()) {
       prop = "file://," + DLJ_BASE_URL;
     }
     return Set.of(prop.split(","));

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
@@ -17,7 +17,6 @@ package com.datastax.oss.streaming.ai.services;
 
 import static com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService.DLJ_BASE_URL;
 
-import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
@@ -67,11 +66,11 @@ public class HuggingFaceServiceProvider implements ServiceProvider {
             AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.builder()
                 .options(options)
                 .arguments(arguments);
-        if (!Strings.isNullOrEmpty(model)) {
+        if (model != null && !model.isEmpty()) {
           builder.modelName(model);
 
           // automatically build the model URL if not provided
-          if (Strings.isNullOrEmpty(modelUrl)) {
+          if (modelUrl == null || modelUrl.isEmpty()) {
             modelUrl = DLJ_BASE_URL + model;
             log.info("Automatically computed model URL {}", modelUrl);
           }
@@ -88,7 +87,7 @@ public class HuggingFaceServiceProvider implements ServiceProvider {
                     .model(model);
 
         String apiUurl = (String) providerConfiguration.get("api-url");
-        if (!Strings.isNullOrEmpty(apiUurl)) {
+        if (apiUurl != null && !apiUurl.isEmpty()) {
           apiBuilder.hfUrl(apiUurl);
         }
         if (options != null && !options.isEmpty()) {


### PR DESCRIPTION
Summary:
The Hugging Face provider relied on a third party shaded library  that may not be on the classpath : com.datastax.oss.driver.shaded.guava.common.base.Strings

This changes removes that dependency