### PR TITLE
Hugging Face: allow to configure the URL to validate the presence of a model

### DIFF
--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceRestEmbeddingService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceRestEmbeddingService.java
@@ -47,6 +47,8 @@ public class HuggingFaceRestEmbeddingService implements EmbeddingsService {
 
     @Builder.Default public String hfUrl = HF_URL;
 
+    @Builder.Default public String hfCheckUrl = HF_CHECK_URL;
+
     @Builder.Default public Map<String, String> options = Map.of("wait_for_model", "true");
   }
 
@@ -61,6 +63,7 @@ public class HuggingFaceRestEmbeddingService implements EmbeddingsService {
   private final String token;
 
   private final URL modelUrl;
+  private final URL checkUrl;
 
   private final HttpClient httpClient;
 
@@ -78,6 +81,7 @@ public class HuggingFaceRestEmbeddingService implements EmbeddingsService {
     this.conf = conf;
     this.model = conf.model;
     this.token = conf.accessKey;
+    this.checkUrl = new URL(conf.hfCheckUrl + model);
     this.modelUrl = new URL(conf.hfUrl + model);
 
     this.httpClient = HttpClient.newHttpClient();
@@ -85,7 +89,7 @@ public class HuggingFaceRestEmbeddingService implements EmbeddingsService {
     try {
       HttpRequest request =
           HttpRequest.newBuilder()
-              .uri(new URL(HF_CHECK_URL + model).toURI())
+              .uri(checkUrl.toURI())
               .header("Authorization", "Bearer " + token)
               .GET()
               .build();

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/config/HuggingFaceConfig.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/config/HuggingFaceConfig.java
@@ -27,6 +27,9 @@ public class HuggingFaceConfig {
   )
   private String apiUrl = "https://api-inference.huggingface.co/pipeline/feature-extraction/";
 
+  @JsonProperty(value = "model-check-url", defaultValue = "https://huggingface.co/api/models/")
+  private String modelUrl = "https://huggingface.co/api/models/";
+
   // for API compute provider
   @JsonProperty(value = "access-key")
   private String accessKey;

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
@@ -90,6 +90,10 @@ public class HuggingFaceServiceProvider implements ServiceProvider {
         if (apiUurl != null && !apiUurl.isEmpty()) {
           apiBuilder.hfUrl(apiUurl);
         }
+        String modelCheckUrl = (String) providerConfiguration.get("model-check-url");
+        if (modelCheckUrl != null && !modelCheckUrl.isEmpty()) {
+          apiBuilder.hfCheckUrl(modelCheckUrl);
+        }
         if (options != null && !options.isEmpty()) {
           apiBuilder.options(options);
         } else {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -65,7 +65,7 @@
             <configuration>
               <tasks>
                 <echo>copy proxy protocol handler</echo>
-                <copy file="${basedir}/../pulsar-transformations/target/pulsar-transformations-${project.version}.nar" tofile="${project.build.outputDirectory}/pulsar-transformations.nar" />
+                <copy file="${basedir}/../pulsar-transformations/target/pulsar-transformations-${project.version}.nar" tofile="${project.build.outputDirectory}/pulsar-transformations.nar"/>
               </tasks>
             </configuration>
           </execution>


### PR DESCRIPTION
In order to write integration tests you need a way to configure the endpoint to validate that a model exists in HF.