### PR TITLE
Compute embeddigs: some small fixes

### DIFF
--- a/pulsar-ai-tools/src/main/resources/config-schema.yaml
+++ b/pulsar-ai-tools/src/main/resources/config-schema.yaml
@@ -274,10 +274,7 @@ components:
             model:
               description: ID of the model to use. See the [model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
               example: "gpt-3.5-turbo"
-              oneOf:
-                - type: string
-                - type: string
-                  enum: [ "gpt-4","gpt-4-0613","gpt-4-32k","gpt-4-32k-0613","gpt-3.5-turbo","gpt-3.5-turbo-16k","gpt-3.5-turbo-0613","gpt-3.5-turbo-16k-0613" ]
+              type: string
             messages:
               description: A list of messages comprising the conversation so far. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb).
               type: array

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -57,6 +57,7 @@ import com.datastax.oss.streaming.ai.services.ServiceProvider;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -328,5 +329,19 @@ public class TransformFunctionUtil {
       return ((Number) o).intValue();
     }
     return Integer.parseInt(o.toString());
+  }
+
+  public static byte[] getBytes(ByteBuffer byteBuffer) {
+    if (byteBuffer == null) {
+      return null;
+    }
+    if (byteBuffer.hasArray() && byteBuffer.arrayOffset() == 0
+            && byteBuffer.array().length == byteBuffer.remaining()) {
+      return byteBuffer.array();
+    }
+    // Direct buffer is not backed by array and it needs to be read from direct memory
+    byte[] array = new byte[byteBuffer.remaining()];
+    byteBuffer.get(array);
+    return array;
   }
 }


### PR DESCRIPTION
Summary:
- remove the list of possible models for compute-ai-embeddings (because we listed the models for openai, now we support multiple other models and also the list of models supported by openai may change in the future)
- fix a problem with JsonConverter and ByteBuffer values