### PR TITLE
Query step: add option only-first to keep only the first line of the resultset

### DIFF
--- a/pulsar-ai-tools/README.md
+++ b/pulsar-ai-tools/README.md
@@ -30,12 +30,17 @@ Step name: `query`
 
 Executes a query against the database configured in the "datasource" section.
 
+The result is a list of rows, each row is a map of fields (the key is a string, the value is always a string).
+In case of no results, the result is an empty list.
+When using the "only-first" parameter, the result is a single row, as a map. In case of no results, the result is an empty map.
+
 Parameters:
 
 | Name         | Description                                                                 |
 |--------------|-----------------------------------------------------------------------------|
 | output-field | The name of the field to add or update (for example value.embeddingsvector) |
 | query        | Template for the query, you can use '?' for parameters                      |
+| only-first   | Keep only the first row and do not return a list                            |
 | fields       | An array of field names to use to fill-in the parameters of the query       |
 
 

--- a/pulsar-ai-tools/src/main/resources/config-schema.yaml
+++ b/pulsar-ai-tools/src/main/resources/config-schema.yaml
@@ -386,6 +386,10 @@ components:
               type:
                 - string
               description: The query.
+            only-first:
+              type:
+                - boolean
+              description: Instead of returning a list of results, keep only the first record or null in case of empty resultset.
             output-field:
               type:
                 - string

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/config/QueryConfig.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/config/QueryConfig.java
@@ -29,4 +29,7 @@ public class QueryConfig extends StepConfig {
 
   @JsonProperty(value = "output-field", required = true)
   private String outputField;
+
+  @JsonProperty(value = "only-first", required = false)
+  private boolean onlyFirst;
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -278,6 +278,7 @@ public class TransformFunctionUtil {
     return QueryStep.builder()
         .outputFieldName(config.getOutputField())
         .query(config.getQuery())
+        .onlyFirst(config.isOnlyFirst())
         .fields(config.getFields())
         .dataSource(dataSource)
         .build();

--- a/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/QueryStepTest.java
+++ b/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/QueryStepTest.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -199,4 +201,73 @@ public class QueryStepTest {
 
     Utils.process(record, queryStep);
   }
+
+    @Test
+    void testOnlyFirst() throws Exception {
+        Schema<KeyValue<String, String>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.STRING, KeyValueEncodingType.SEPARATED);
+
+        String key = "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}";
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+
+        KeyValue<String, String> keyValue = new KeyValue<>(key, value);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        List<String> fields = List.of();
+        QueryStepDataSource dataSource =
+                new QueryStepDataSource() {
+                    @Override
+                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                        List<Object> expectedParams = List.of();
+                        assertEquals(params, expectedParams);
+                        switch (query) {
+                            case "select a,b from test":
+                                return List.of(Map.of("a", "10", "b", "foo"),
+                                               Map.of("a", "20", "b", "bar"));
+                            case "select a,b from test where 1=0":
+                                return List.of(Map.of());
+                            default:
+                            throw new RuntimeException("Unexpected query: " + query);
+                        }
+                    }
+                };
+
+        QueryStep queryStepFindSomeResults =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select a,b from test")
+                        .onlyFirst(true)
+                        .fields(fields)
+                        .build();
+        Record<?> result = Utils.process(record, queryStepFindSomeResults);
+        KeyValue<String, String> keyValueResult = (KeyValue<String, String>) result.getValue();
+        Map<String, Object> parsed = new ObjectMapper().readValue(keyValueResult.getValue(), Map.class);
+        assertEquals(parsed, Map.of("valueField1", "value1",
+                                    "valueField2", "value2",
+                                    "valueField3", "value3",
+                                    "result", Map.of("b", "foo", "a", "10")));
+
+        QueryStep queryStepFindNoResults =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select a,b from test where 1=0")
+                        .onlyFirst(true)
+                        .fields(fields)
+                        .build();
+        Record<KeyValue<String, String>> resultNoResults = Utils.process(record, queryStepFindNoResults);
+        KeyValue<String, String> keyValueResultNoResults = resultNoResults.getValue();
+        Map<String, Object> parsedNoResults = new ObjectMapper().readValue(keyValueResultNoResults.getValue(), Map.class);
+        assertEquals(parsedNoResults, Map.of("valueField1", "value1",
+                "valueField2", "value2",
+                "valueField3", "value3",
+                "result", Map.of()));
+    }
 }

--- a/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/Utils.java
+++ b/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/Utils.java
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
 @Slf4j
 public class Utils {
 
-  public static Record<GenericObject> process(Record<GenericObject> record, TransformStep step)
+  public static <T> Record<T> process(Record<GenericObject> record, TransformStep step)
       throws Exception {
     Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
     TransformContext transformContext =
@@ -464,7 +464,7 @@ public class Utils {
     }
   }
 
-  public static Record<GenericObject> send(Context context, TransformContext transformContext)
+  public static <T> Record<T> send(Context context, TransformContext transformContext)
       throws IOException {
     if (transformContext.isDropCurrentRecord()) {
       return null;
@@ -498,7 +498,7 @@ public class Utils {
       log.debug("output {} schema {}", outputObject, outputSchema);
     }
 
-    FunctionRecord.FunctionRecordBuilder<GenericObject> recordBuilder =
+    FunctionRecord.FunctionRecordBuilder<T> recordBuilder =
         context
             .newOutputRecordBuilder(outputSchema)
             .destinationTopic(transformContext.getOutputTopic())


### PR DESCRIPTION
Summary:
- add a new option "only-first" to return only a map containing the first row of the result set 
- add docs