### PR TITLE
Compute Step: add toInt, toDouble and filter(list, expression) functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ The Expression Language supports the following operators:
 Utility methods available under the `fn` namespace.
 For example, to get the current timestamp, use 'fn:now()'.
 The Expression Language supports the following functions:
+* `toDouble(input)`: Converts the input value to a DOUBLE number, If the input is `null`, it returns `null`.
+* `toInt(input)`: Converts the input value to an INTEGER number, If the input is `null`, it returns `null`.
 * `uppercase(input)`: Returns the string `input` uppercased, If the input is `null`, it returns `null`.
 * `lowercase(input)`: Returns the string `input` lowercased, If the input is `null`, it returns `null`.
 * `contains(input, value)`: Returns the boolean `true` if `value` exists in `input`. If `input` or `value` is `null`, it returns `false`. 
@@ -297,6 +299,7 @@ The Expression Language supports the following functions:
   * `scale` the scale of the `BigDecimal` to create.
 * `decimalFromNumber(input)`: Converts `input` to a `BigDecimal`.
     * `input` value of the BigDecimal in DOUBLE or FLOAT. If INTEGER or LONG is provided, an unscaled BigDecimal value will be returned.
+* `filter(collection, expression)`: Returns a new collection containing only the elements of `collection` for which `expression` is `true`. The current element is available under the `record` variable. An example is fn:filter(value.queryResults, "fn:toDouble(record.similarity) >= 0.5")
 For all methods, if a parameter is not in the right type, a conversion will be done using the rules described in [Type conversions](#type-conversions).
 For instance, you can do `fn:timestampAdd('2022-10-02T01:02:03Z', '42', 'hours'.bytes)`
 

--- a/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
+++ b/pulsar-transformations/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
@@ -21,9 +21,16 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.AssertJUnit.assertNull;
 
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.util.Utf8;
 import org.apache.pulsar.client.api.Schema;
@@ -42,6 +49,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+@Slf4j
 public class TransformFunctionTest {
 
   @DataProvider(name = "validConfigs")
@@ -512,5 +520,35 @@ public class TransformFunctionTest {
         outputRecord.getValue(),
         "{\"keyField2\":\"key2\",\"keyField3\":\"key3\",\"valueField1\":"
             + "\"value1\",\"valueField2\":\"value2\",\"valueField3\":\"value3\"}");
+  }
+
+  @Test
+  void testComputeFilterList() throws Exception {
+    String userConfig =
+            (""
+                    + "{'steps': ["
+                    + "    {'type': 'compute', 'fields':["
+                    + "        {'name': 'value.newQueryResults', 'expression' : 'fn:filter(value.queryResults, \\'true\\')'}"
+                    + "    ]}"
+                    + "]}")
+                    .replace("'", "\"");
+
+    Map<String, Object> config =
+            new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+    TransformFunction transformFunction = new TransformFunction();
+
+    String value = "{\"queryResults\":[" +
+            "{" +
+            "\"v1\":\"v2\"" +
+            "}" +
+            "]}";
+    Utils.TestRecord<String> testRecord = new Utils.TestRecord<>(Schema.STRING, value, null);
+    Utils.TestContext context = new Utils.TestContext(testRecord, config);
+    transformFunction.initialize(context);
+    TransformContext transformContext = TransformFunction.newTransformContext(context, value, true);
+    transformFunction.process(transformContext);
+    log.info("result: {} {}", transformContext.getValueObject(), transformContext.getValueObject().getClass());
+    assertEquals(Map.of("queryResults", List.of(Map.of("v1", "v2")), "newQueryResults", List.of(Map.of("v1","v2"))),
+            transformContext.getValueObject());
   }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ComputeStep.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ComputeStep.java
@@ -301,6 +301,9 @@ public class ComputeStep implements TransformStep {
       case BYTES:
         schemaType = Schema.Type.BYTES;
         break;
+      case ARRAY:
+        schemaType = Schema.Type.ARRAY;
+        break;
       case DECIMAL:
         // disable caching for decimal schema because the schema is different for each precision and
         // scale combo and will result in an arbitrary numbers of schemas
@@ -484,6 +487,9 @@ public class ComputeStep implements TransformStep {
     }
     if (value.getClass().equals(BigDecimal.class)) {
       return ComputeFieldType.DECIMAL;
+    }
+    if (List.class.isAssignableFrom(value.getClass())) {
+      return ComputeFieldType.ARRAY;
     }
     throw new UnsupportedOperationException("Got an unsupported type: " + value.getClass());
   }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ComputeStep.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/ComputeStep.java
@@ -318,6 +318,12 @@ public class ComputeStep implements TransformStep {
     return fieldTypeToAvroSchemaCache.computeIfAbsent(
         type,
         key -> {
+
+          if (schemaType == Schema.Type.ARRAY) {
+            // we don't know the element type of the array, so we can't create a schema
+            return Schema.createArray(Schema.createMap(Schema.create(Schema.Type.STRING)));
+          }
+
           // Handle logical types: https://avro.apache.org/docs/1.10.2/spec.html#Logical+Types
           Schema schema = Schema.create(schemaType);
           switch (key) {

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/QueryStep.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/QueryStep.java
@@ -98,11 +98,7 @@ public class QueryStep implements TransformStep {
     }
 
     transformContext.setResultField(
-            finalResult,
-        outputFieldName,
-        schema,
-        avroKeySchemaCache,
-        avroValueSchemaCache);
+        finalResult, outputFieldName, schema, avroKeySchemaCache, avroValueSchemaCache);
   }
 
   private Object getField(

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/TransformContext.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/TransformContext.java
@@ -54,6 +54,8 @@ public class TransformContext {
   private Long eventTime;
   private boolean dropCurrentRecord;
   Map<String, Object> customContext = new HashMap<>();
+  // only for fn:filter
+  private Object recordObject;
 
   public void convertMapToStringOrBytes() throws JsonProcessingException {
     if (valueObject instanceof Map) {

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluator.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluator.java
@@ -67,6 +67,12 @@ public class JstlEvaluator<T> {
         .mapFunction("fn", "str", JstlFunctions.class.getMethod("toString", Object.class));
     this.expressionContext
         .getFunctionMapper()
+        .mapFunction("fn", "toDouble", JstlFunctions.class.getMethod("toDouble", Object.class));
+    this.expressionContext
+        .getFunctionMapper()
+        .mapFunction("fn", "toInt", JstlFunctions.class.getMethod("toInt", Object.class));
+    this.expressionContext
+        .getFunctionMapper()
         .mapFunction(
             "fn",
             "replace",
@@ -110,6 +116,11 @@ public class JstlEvaluator<T> {
     FACTORY
         .createValueExpression(expressionContext, "${value}", Object.class)
         .setValue(expressionContext, adapter.adaptValue());
+
+    // this is only for fn:filter
+    FACTORY
+        .createValueExpression(expressionContext, "${record}", Object.class)
+        .setValue(expressionContext, adapter.adaptRecord());
 
     // Register message headers as top level fields
     FACTORY

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluator.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluator.java
@@ -69,6 +69,9 @@ public class JstlEvaluator<T> {
         .getFunctionMapper()
         .mapFunction("fn", "toDouble", JstlFunctions.class.getMethod("toDouble", Object.class));
     this.expressionContext
+            .getFunctionMapper()
+            .mapFunction("fn", "filter", JstlFunctions.class.getMethod("filter", Object.class, String.class));
+    this.expressionContext
         .getFunctionMapper()
         .mapFunction("fn", "toInt", JstlFunctions.class.getMethod("toInt", Object.class));
     this.expressionContext

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlTransformContextAdapter.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlTransformContextAdapter.java
@@ -140,6 +140,10 @@ public class JstlTransformContextAdapter {
         : valueObject;
   }
 
+  public Object adaptRecord() {
+    return transformContext.getRecordObject();
+  }
+
   public Map<String, Object> getHeader() {
     return lazyHeader;
   }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/ComputeFieldType.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/model/ComputeFieldType.java
@@ -38,5 +38,6 @@ public enum ComputeFieldType {
   @Deprecated
   DATETIME,
   BYTES,
-  DECIMAL
+  DECIMAL,
+  ARRAY
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/JsonConverter.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/JsonConverter.java
@@ -15,7 +15,8 @@
  */
 package com.datastax.oss.streaming.ai.util;
 
-import ai.djl.util.Utils;
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getBytes;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -35,8 +36,6 @@ import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
-
-import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getBytes;
 
 /** Convert an AVRO GenericRecord to a JsonNode. */
 public class JsonConverter {
@@ -83,8 +82,9 @@ public class JsonConverter {
         } else if (value instanceof ByteBuffer) {
           bytes = getBytes((ByteBuffer) value);
         } else {
-            throw new IllegalArgumentException(
-                "Invalid type for field of type BYTES, expected byte[] or ByteBuffer but was " + value.getClass());
+          throw new IllegalArgumentException(
+              "Invalid type for field of type BYTES, expected byte[] or ByteBuffer but was "
+                  + value.getClass());
         }
         return jsonNodeFactory.binaryNode(bytes);
       case FIXED:

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -336,8 +336,9 @@ public class TransformFunctionUtil {
     if (byteBuffer == null) {
       return null;
     }
-    if (byteBuffer.hasArray() && byteBuffer.arrayOffset() == 0
-            && byteBuffer.array().length == byteBuffer.remaining()) {
+    if (byteBuffer.hasArray()
+        && byteBuffer.arrayOffset() == 0
+        && byteBuffer.array().length == byteBuffer.remaining()) {
       return byteBuffer.array();
     }
     // Direct buffer is not backed by array and it needs to be read from direct memory

--- a/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSourceTest.java
+++ b/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSourceTest.java
@@ -38,7 +38,7 @@ public class AstraDBDataSourceTest {
     log.info("maps {}", maps);
   }
 
-  @Test(enabled = false)
+  @Test
   void testQueryWithVectorSearch() throws Exception {
     AstraDBDataSource source = new AstraDBDataSource();
     DataSourceConfig dataSourceConfig = buildDataSourceConfig();

--- a/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSourceTest.java
+++ b/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSourceTest.java
@@ -38,7 +38,7 @@ public class AstraDBDataSourceTest {
     log.info("maps {}", maps);
   }
 
-  @Test
+  @Test(enabled = false)
   void testQueryWithVectorSearch() throws Exception {
     AstraDBDataSource source = new AstraDBDataSource();
     DataSourceConfig dataSourceConfig = buildDataSourceConfig();

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -65,7 +65,7 @@
             <configuration>
               <tasks>
                 <echo>copy proxy protocol handler</echo>
-                <copy file="${basedir}/../pulsar-transformations/target/pulsar-transformations-${project.version}.nar" tofile="${project.build.outputDirectory}/pulsar-transformations.nar" />
+                <copy file="${basedir}/../pulsar-transformations/target/pulsar-transformations-${project.version}.nar" tofile="${project.build.outputDirectory}/pulsar-transformations.nar"/>
               </tasks>
             </configuration>
           </execution>


### PR DESCRIPTION
Summary:
- add new built-in functions to the compute step
- add README


* fn:toDouble: converts a value to a double
* fn:toInt: converts a value to an integer
* fn:filter(list, expression): filter a list type and keep only some values


The main usage is:
- perform a "query" step and assign the results to a `value.results` field in the message
- run `compute` step  to filter some of the values and create a new list


```
"fields":[
     {
       "name": "value.filteredResults", 
       "expression" : "fn:filter(value.results,'fn:toDouble(record.similarity) > 0.7')"
     }
]
```

Please note that it is important to use "fn:toDouble" because the "query" step aways return string values and you have to convert the value to "double" in order to perform the evaluation correctly.
     
