### PR TITLE
deps: Update azure-ai-openai version  to fix CVE-2023-34062

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <surefire.version>3.0.0-M5</surefire.version>
     <!-- Must match version in pulsar -->
     <avro.version>1.10.2</avro.version>
-    <azure-ai-openai.version>1.0.0-beta.2</azure-ai-openai.version>
+    <azure-ai-openai.version>1.0.0-beta.6</azure-ai-openai.version>
     <cassandra.driver.version>4.16.0</cassandra.driver.version>
     <nifi-nar-maven-plugin.version>1.5.1</nifi-nar-maven-plugin.version>
     <djl.version>0.22.1</djl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <surefire.version>3.0.0-M5</surefire.version>
     <!-- Must match version in pulsar -->
     <avro.version>1.10.2</avro.version>
-    <azure-ai-openai.version>1.0.0-beta.6</azure-ai-openai.version>
+    <azure-ai-openai.version>1.0.0-beta.8</azure-ai-openai.version>
     <cassandra.driver.version>4.16.0</cassandra.driver.version>
     <nifi-nar-maven-plugin.version>1.5.1</nifi-nar-maven-plugin.version>
     <djl.version>0.22.1</djl.version>

--- a/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
+++ b/pulsar-ai-tools/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertThrows;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.azure.ai.openai.models.ChatRequestUserMessage;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
 import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
 import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
@@ -210,7 +211,9 @@ public class AIToolsTest {
         ArgumentCaptor.forClass(ChatCompletionsOptions.class);
     verify(client).getChatCompletions(eq("test-model"), captor.capture());
 
-    assertEquals(captor.getValue().getMessages().get(0).getContent(), "value1 key2");
+    ChatRequestUserMessage message =
+        (ChatRequestUserMessage) captor.getValue().getMessages().get(0);
+    assertEquals(message.getContent().toString(), "value1 key2");
   }
 
   @Test
@@ -270,7 +273,7 @@ public class AIToolsTest {
     assertEquals("result", valueAvroRecord.get("completion").toString());
     assertEquals(
         valueAvroRecord.get("log").toString(),
-        "{\"options\":{\"max_tokens\":null,\"temperature\":null,\"top_p\":null,\"logit_bias\":null,\"user\":null,\"n\":null,\"stop\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"stream\":null,\"model\":\"test-model\"},\"messages\":[{\"role\":\"user\",\"content\":\"value1 key2\"}],\"model\":\"test-model\"}");
+        "{\"options\":{\"max_tokens\":null,\"temperature\":null,\"top_p\":null,\"logit_bias\":null,\"user\":null,\"n\":null,\"stop\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"stream\":null,\"model\":\"test-model\",\"functions\":null,\"function_call\":null,\"data_sources\":null,\"enhancements\":null,\"seed\":null,\"response_format\":null,\"tools\":null,\"tool_choice\":null,\"logprobs\":null,\"top_logprobs\":null},\"messages\":[{\"role\":\"user\",\"content\":\"value1 key2\"}],\"model\":\"test-model\"}");
   }
 
   @Test

--- a/pulsar-transformations/pom.xml
+++ b/pulsar-transformations/pom.xml
@@ -146,6 +146,11 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+      <version>1.48.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
@@ -20,6 +20,8 @@ import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getIntege
 
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.*;
+
+import javax.management.relation.RoleNotFoundException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -71,7 +73,7 @@ public class OpenAICompletionService implements CompletionsService {
       case "tool":
         return new ChatRequestToolMessage(message.getContent(), "");
       default:
-        return new ChatRequestMessage();
+        throw new IllegalArgumentException("Unsupported Chat Role: " + message.getRole());
     }
   }
 

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
@@ -19,8 +19,7 @@ import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getDouble
 import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getInteger;
 
 import com.azure.ai.openai.OpenAIClient;
-import com.azure.ai.openai.models.ChatCompletionsOptions;
-import com.azure.ai.openai.models.ChatRole;
+import com.azure.ai.openai.models.*;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -38,14 +37,7 @@ public class OpenAICompletionService implements CompletionsService {
       List<ChatMessage> messages, Map<String, Object> options) {
     ChatCompletionsOptions chatCompletionsOptions =
         new ChatCompletionsOptions(
-                messages
-                    .stream()
-                    .map(
-                        message ->
-                            new com.azure.ai.openai.models.ChatMessage(
-                                    ChatRole.fromString(message.getRole()))
-                                .setContent(message.getContent()))
-                    .collect(Collectors.toList()))
+                messages.stream().map(this::getChatRequestMessage).collect(Collectors.toList()))
             .setMaxTokens(getInteger("max-tokens", options))
             .setTemperature(getDouble("temperature", options))
             .setTopP(getDouble("top-p", options))
@@ -66,8 +58,25 @@ public class OpenAICompletionService implements CompletionsService {
     return result;
   }
 
+  private ChatRequestMessage getChatRequestMessage(ChatMessage message) {
+    switch (message.getRole()) {
+      case "system":
+        return new ChatRequestSystemMessage(message.getContent());
+      case "assistant":
+        return new ChatRequestAssistantMessage(message.getContent());
+      case "user":
+        return new ChatRequestUserMessage(message.getContent());
+      case "function":
+        return new ChatRequestFunctionMessage("", message.getContent());
+      case "tool":
+        return new ChatRequestToolMessage(message.getContent(), "");
+      default:
+        return new ChatRequestMessage();
+    }
+  }
+
   private static ChatMessage convertMessage(com.azure.ai.openai.models.ChatChoice c) {
-    com.azure.ai.openai.models.ChatMessage message = c.getMessage();
+    com.azure.ai.openai.models.ChatResponseMessage message = c.getMessage();
     return new ChatMessage(
         message.getRole() != null ? message.getRole().toString() : null, message.getContent());
   }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
@@ -20,8 +20,6 @@ import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getIntege
 
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.*;
-
-import javax.management.relation.RoleNotFoundException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
@@ -38,7 +38,13 @@ public class OpenAIEmbeddingsService implements EmbeddingsService {
     return embeddings
         .getData()
         .stream()
-        .map(embedding -> embedding.getEmbedding())
+        .map(
+            embedding ->
+                embedding
+                    .getEmbedding()
+                    .stream()
+                    .map(floatEmbedding -> (double) floatEmbedding)
+                    .collect(Collectors.toList()))
         .collect(Collectors.toList());
   }
 }

--- a/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/streaming-ai/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -17,8 +17,8 @@ package com.datastax.oss.streaming.ai.util;
 
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
-import com.azure.ai.openai.models.NonAzureOpenAIKeyCredential;
 import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.credential.KeyCredential;
 import com.datastax.oss.streaming.ai.CastStep;
 import com.datastax.oss.streaming.ai.ChatCompletionsStep;
 import com.datastax.oss.streaming.ai.ComputeAIEmbeddingsStep;
@@ -83,7 +83,7 @@ public class TransformFunctionUtil {
     if (openAIConfig.getProvider() == OpenAIProvider.AZURE) {
       openAIClientBuilder.credential(new AzureKeyCredential(openAIConfig.getAccessKey()));
     } else {
-      openAIClientBuilder.credential(new NonAzureOpenAIKeyCredential(openAIConfig.getAccessKey()));
+      openAIClientBuilder.credential(new KeyCredential(openAIConfig.getAccessKey()));
     }
     if (openAIConfig.getUrl() != null) {
       openAIClientBuilder.endpoint(openAIConfig.getUrl());

--- a/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
+++ b/streaming-ai/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertEquals;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.azure.ai.openai.models.ChatRequestUserMessage;
 import com.datastax.oss.streaming.ai.completions.ChatMessage;
 import com.datastax.oss.streaming.ai.completions.OpenAICompletionService;
 import com.datastax.oss.streaming.ai.model.config.ChatCompletionsConfig;
@@ -111,8 +112,10 @@ public class ChatCompletionsStepTest {
     Utils.process(record, new ChatCompletionsStep(completionService, config));
     verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
 
+    ChatRequestUserMessage message =
+        (ChatRequestUserMessage) captor.getValue().getMessages().get(0);
     assertEquals(
-        captor.getValue().getMessages().get(0).getContent(),
+        message.getContent().toString(),
         "test-message test-key 42 test-input-topic test-output-topic test-value");
   }
 
@@ -160,9 +163,10 @@ public class ChatCompletionsStepTest {
         ArgumentCaptor.forClass(ChatCompletionsOptions.class);
     verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
 
+    ChatRequestUserMessage message =
+        (ChatRequestUserMessage) captor.getValue().getMessages().get(0);
     assertEquals(
-        captor.getValue().getMessages().get(0).getContent(),
-        "Jane Doe 42 19359 1672700645006 83045006 test-key");
+        message.getContent().toString(), "Jane Doe 42 19359 1672700645006 83045006 test-key");
   }
 
   @DataProvider(name = "jsonStringSchemas")
@@ -197,10 +201,10 @@ public class ChatCompletionsStepTest {
     ArgumentCaptor<ChatCompletionsOptions> captor =
         ArgumentCaptor.forClass(ChatCompletionsOptions.class);
     verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
-
+    ChatRequestUserMessage message =
+        (ChatRequestUserMessage) captor.getValue().getMessages().get(0);
     assertEquals(
-        captor.getValue().getMessages().get(0).getContent(),
-        "Jane Doe 42 19359 1672700645006 83045006 test-key");
+        message.getContent().toString(), "Jane Doe 42 19359 1672700645006 83045006 test-key");
   }
 
   @Test(dataProvider = "structuredSchemaTypes")
@@ -215,8 +219,9 @@ public class ChatCompletionsStepTest {
         Utils.createTestStructKeyValueRecord(schemaType),
         new ChatCompletionsStep(completionService, config));
     verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
-
-    assertEquals(captor.getValue().getMessages().get(0).getContent(), "value1 key2");
+    ChatRequestUserMessage message =
+        (ChatRequestUserMessage) captor.getValue().getMessages().get(0);
+    assertEquals(message.getContent().toString(), "value1 key2");
   }
 
   @Test(dataProvider = "jsonStringSchemas")
@@ -248,9 +253,10 @@ public class ChatCompletionsStepTest {
         ArgumentCaptor.forClass(ChatCompletionsOptions.class);
     verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
 
+    ChatRequestUserMessage message =
+        (ChatRequestUserMessage) captor.getValue().getMessages().get(0);
     assertEquals(
-        captor.getValue().getMessages().get(0).getContent(),
-        "Jane Doe 42 19359 1672700645006 83045006 test-key");
+        message.getContent().toString(), "Jane Doe 42 19359 1672700645006 83045006 test-key");
   }
 
   @Test


### PR DESCRIPTION
This PR fixes CVE-2023-34062 ( http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-34062)

CVE-2023-34062 is cause by
- io.projectreactor.netty:reactor-netty-http@1.0.31
- io.projectreactor.netty:reactor-netty-core@1.0.31

By upgrading azure-ai-openai version to 1.0.0-beta.6 
It upgrades the versions to 
- io.projectreactor.netty:reactor-netty-http@1.0.39
- io.projectreactor.netty:reactor-netty-core@1.0.39