### PR TITLE
Replaced deprecated 'tasks' with 'target' for maven-antrun-plugin

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -56,6 +56,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>process-test-resources</phase>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -63,12 +63,12 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <echo>copy proxy protocol handler</echo>
                 <copy file="${basedir}/../pulsar-transformations/target/pulsar-transformations-${project.version}.nar" tofile="${project.build.outputDirectory}/pulsar-transformations.nar">
                   <!-- this comment prevents mvn release plugin to wrongly reformat the pom -->
                 </copy>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Replace `tasks` which was removed in version 3.0.0 of the `maven-antrun-pulgin` plugin with `target`.