### PR TITLE
Upgrade Avro to 1.11.4 to address CVE-2024-47561

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <pulsar.version>2.10.2.5</pulsar.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <!-- Must match version in pulsar -->
-    <avro.version>1.10.2</avro.version>
+    <avro.version>1.11.4</avro.version>
     <azure-ai-openai.version>1.0.0-beta.8</azure-ai-openai.version>
     <cassandra.driver.version>4.16.0</cassandra.driver.version>
     <nifi-nar-maven-plugin.version>1.5.1</nifi-nar-maven-plugin.version>


### PR DESCRIPTION
# Motivation

Avro 1.11.3 contains critical 9.3/10 level RCE vulnerability in Avro Java SDK <1.11.4, [CVE-2024-47561](https://github.com/advisories/GHSA-r7pg-v2c8-mfg3)>